### PR TITLE
Strongly constrain the package versions we use.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,11 +10,10 @@
   "author": "Holger Rapp <hrapp@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/dat-gui": "^0.6.1",
+    "@types/dat-gui": "0.6.1",
     "@types/three": "0.0.27",
-    "@types/whatwg-fetch": "0.0.33",
-    "dat-gui": "^0.5.0",
-    "three": "^0.83.0",
-    "typescript": "^2.0"
+    "dat-gui": "0.5.0",
+    "three": "0.83.0",
+    "typescript": "^2.2"
   }
 }


### PR DESCRIPTION
Fixes googlecartographer/cartographer_ros#271.