### PR TITLE
Performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ scoped-pool = "^0.1"
 time = "^0.1.35"
 urlencoded = "^0.3.0"
 walkdir = "^0.1.5"
+
+[profile.release]
+lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,12 @@ pub mod ply;
 pub mod pts;
 pub mod errors;
 
-#[derive(Debug)]
+pub trait InternalIterator {
+    fn for_each<F: FnMut(&Point)>(self, F);
+    fn size_hint(&self) -> Option<usize>;
+}
+
+#[derive(Debug,Clone)]
 pub struct Point {
     pub position: math::Vector3f,
     pub r: u8,

--- a/src/pts.rs
+++ b/src/pts.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use math::Vector3f;
-use Point;
+use {InternalIterator, Point};
 use std::fs::File;
 use std::io::{BufReader, BufRead};
 use std::path::Path;
@@ -30,29 +30,33 @@ impl PtsIterator {
     }
 }
 
-impl Iterator for PtsIterator {
-    type Item = Point;
+impl InternalIterator for PtsIterator {
+    fn size_hint(&self) -> Option<usize> {
+        None
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
+    fn for_each<F: FnMut(&Point)>(mut self, mut f: F) {
+        let mut line = String::new();
         loop {
-            let mut line = String::new();
+            line.clear();
             self.data.read_line(&mut line).unwrap();
             if line.is_empty() {
-                return None;
+                break;
             }
 
             let parts: Vec<&str> = line.trim().split(|c| c == ' ' || c == ',').collect();
             if parts.len() != 7 {
                 continue;
             }
-            return Some(Point {
+            let p = Point {
                 position: Vector3f::new(parts[0].parse::<f32>().unwrap(),
                                         parts[1].parse::<f32>().unwrap(),
                                         parts[2].parse::<f32>().unwrap()),
                 r: parts[4].parse::<u8>().unwrap(),
                 g: parts[5].parse::<u8>().unwrap(),
                 b: parts[6].parse::<u8>().unwrap(),
-            });
+            };
+            f(&p);
         }
     }
 }


### PR DESCRIPTION
- Use an internal iterator instead of a boxed iterator. This is better semantics, since we do not plan to support iterating over the same octree in parallel. It is also faster since it allows for inlining of the callback function at each call site. This buys ~11% performance.
- Use an enum to represent the file input data stream since the number of input formats is finite.
- Activate link time optimization for release builds. This buys another 4%, but increases link time.

