### PR TITLE
Correctly subsample up to the root

### DIFF
--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -134,7 +134,7 @@ impl Octree {
             }
             let file_name = path.file_name().unwrap();
             let file_name_str = file_name.to_str().unwrap();
-            if !file_name_str.starts_with("r") && file_name_str.ends_with(".xyz") {
+            if !file_name_str.starts_with("r") && !file_name_str.ends_with(".xyz") {
                 continue;
             }
             let num_points = fs::metadata(path).unwrap().len() / 12;

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -134,7 +134,7 @@ impl Octree {
             }
             let file_name = path.file_name().unwrap();
             let file_name_str = file_name.to_str().unwrap();
-            if !file_name_str.starts_with("r") && !file_name_str.ends_with(".xyz") {
+            if !file_name_str.starts_with("r") || !file_name_str.ends_with(".xyz") {
                 continue;
             }
             let num_points = fs::metadata(path).unwrap().len() / 12;


### PR DESCRIPTION
A thinko was in this code: if a node was generated by subsampling children, we inserted its parent to be a new leaf node. That was incorrect, in fact the node itself is a new leaf node and its parent must also be generated from subsampling.

Fixes #22.