### PR TITLE
Minor: fix web_viewer paths in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ The `web_viewer` consists of [TypeScript](https://www.typescriptlang.org) code r
 
 To build,
 
-1. Change into the client directory: `cd client`.
+1. Change into the web viewer's client directory: `cd web_viewer/client`.
 2. Install npm. We strongly suggest using [nvm](https://github.com/creationix/nvm).
 3. Install javascript dependencies: `npm install`.
 4. Build the client: `npm run build`.
 
 Then build the server: `cargo build --release`.
-Serve up the octree using `target/release/web_viewer <octree directory>`, open Chrome to <http://localhost:5433>, navigate with WASD and left-click-drag on the mouse.
+Serve up the octree using `web_viewer/target/release/web_viewer <octree directory>`, open Chrome to <http://localhost:5433>, navigate with WASD and left-click-drag on the mouse.
 The mouse wheel adjusts movement speed.
 
 The client files (HTML and JavaScript) are embedded in the `web_viewer` binary, so it is fully stand alone.


### PR DESCRIPTION
Just a small patch for the build instructions to avoid confusion between the target folder in the base directory and the `web_viewer` folder (at least that's what I had to do on my machine).