### PR TITLE
Switch to using StructGenerator from glbindings

### DIFF
--- a/sdl_viewer/build.rs
+++ b/sdl_viewer/build.rs
@@ -1,6 +1,6 @@
 extern crate gl_generator;
 
-use gl_generator::{Api, Fallbacks, GlobalGenerator, Profile, Registry};
+use gl_generator::{Api, Fallbacks, StructGenerator, Profile, Registry};
 use std::env;
 use std::fs::File;
 use std::path::Path;
@@ -10,6 +10,6 @@ fn main() {
     let mut file = File::create(&Path::new(&dest).join("bindings.rs")).unwrap();
 
     Registry::new(Api::Gl, (3, 2), Profile::Core, Fallbacks::All, [])
-        .write_bindings(GlobalGenerator, &mut file)
+        .write_bindings(StructGenerator, &mut file)
         .unwrap();
 }

--- a/sdl_viewer/src/box_drawer.rs
+++ b/sdl_viewer/src/box_drawer.rs
@@ -25,7 +25,6 @@ const FRAGMENT_SHADER_OUTLINED_BOX: &'static str = include_str!("../shaders/box_
 const VERTEX_SHADER_OUTLINED_BOX: &'static str = include_str!("../shaders/box_drawer_outline.vs");
 
 pub struct BoxDrawer<'a> {
-    gl: &'a opengl::Gl,
     outline_program: GlProgram<'a>,
 
     // Uniforms locations.
@@ -107,7 +106,6 @@ impl<'a> BoxDrawer<'a> {
             );
         }
         BoxDrawer {
-            gl,
             outline_program,
             u_transform,
             u_color,
@@ -122,16 +120,16 @@ impl<'a> BoxDrawer<'a> {
         self.vertex_array.bind();
 
         unsafe {
-            self.gl.UseProgram(self.outline_program.id);
-            self.gl.UniformMatrix4fv(self.u_transform, 1, false as GLboolean, transform.as_ptr());
-            self.gl.Uniform4f(
+            self.outline_program.gl.UseProgram(self.outline_program.id);
+            self.outline_program.gl.UniformMatrix4fv(self.u_transform, 1, false as GLboolean, transform.as_ptr());
+            self.outline_program.gl.Uniform4f(
                 self.u_color,
                 color.red,
                 color.green,
                 color.blue,
                 color.alpha,
             );
-            self.gl.DrawElements(opengl::LINES, 24, opengl::UNSIGNED_INT, ptr::null());
+            self.outline_program.gl.DrawElements(opengl::LINES, 24, opengl::UNSIGNED_INT, ptr::null());
         }
     }
 

--- a/sdl_viewer/src/box_drawer.rs
+++ b/sdl_viewer/src/box_drawer.rs
@@ -14,8 +14,8 @@
 
 use cgmath::{Matrix, Matrix4};
 use color::Color;
-use gl;
-use gl::types::{GLboolean, GLint, GLsizeiptr, GLuint};
+use opengl;
+use opengl::types::{GLboolean, GLint, GLsizeiptr, GLuint};
 use graphic::{GlBuffer, GlProgram, GlVertexArray};
 use point_viewer::math::{Cube, CuboidLike};
 use std::mem;
@@ -24,37 +24,38 @@ use std::ptr;
 const FRAGMENT_SHADER_OUTLINED_BOX: &'static str = include_str!("../shaders/box_drawer_outline.fs");
 const VERTEX_SHADER_OUTLINED_BOX: &'static str = include_str!("../shaders/box_drawer_outline.vs");
 
-pub struct BoxDrawer {
-    outline_program: GlProgram,
+pub struct BoxDrawer<'a> {
+    gl: &'a opengl::Gl,
+    outline_program: GlProgram<'a>,
 
     // Uniforms locations.
     u_transform: GLint,
     u_color: GLint,
 
     // Vertex array and buffers
-    vertex_array: GlVertexArray,
-    _buffer_position: GlBuffer,
-    _buffer_indices: GlBuffer,
+    vertex_array: GlVertexArray<'a>,
+    _buffer_position: GlBuffer<'a>,
+    _buffer_indices: GlBuffer<'a>,
 }
 
-impl BoxDrawer {
-    pub fn new() -> Self {
+impl<'a> BoxDrawer<'a> {
+    pub fn new(gl: &'a opengl::Gl) -> Self {
         let outline_program =
-            GlProgram::new(VERTEX_SHADER_OUTLINED_BOX, FRAGMENT_SHADER_OUTLINED_BOX);
+            GlProgram::new(gl, VERTEX_SHADER_OUTLINED_BOX, FRAGMENT_SHADER_OUTLINED_BOX);
         let u_transform;
         let u_color;
 
         unsafe {
-            gl::UseProgram(outline_program.id);
-            u_transform = gl::GetUniformLocation(outline_program.id, c_str!("transform"));
-            u_color = gl::GetUniformLocation(outline_program.id, c_str!("color"));
+            gl.UseProgram(outline_program.id);
+            u_transform = gl.GetUniformLocation(outline_program.id, c_str!("transform"));
+            u_color = gl.GetUniformLocation(outline_program.id, c_str!("color"));
         }
 
-        let vertex_array = GlVertexArray::new();
+        let vertex_array = GlVertexArray::new(gl);
         vertex_array.bind();
 
         // vertex buffer: define 8 vertices of the box
-        let _buffer_position = GlBuffer::new_array_buffer();
+        let _buffer_position = GlBuffer::new_array_buffer(gl);
         _buffer_position.bind();
         let vertices: [[f32; 3]; 8] = [
             [-1.0, -1.0,  1.0],   // vertices of front quad
@@ -67,16 +68,16 @@ impl BoxDrawer {
             [-1.0,  1.0, -1.0],   //
         ];
         unsafe {
-            gl::BufferData(
-                gl::ARRAY_BUFFER,
+            gl.BufferData(
+                opengl::ARRAY_BUFFER,
                 (vertices.len() * 3 * mem::size_of::<f32>()) as GLsizeiptr,
                 mem::transmute(&vertices[0]),
-                gl::STATIC_DRAW,
+                opengl::STATIC_DRAW,
             );
         }
 
         // define index buffer for 24 edges of the box
-        let _buffer_indices = GlBuffer::new_element_array_buffer();
+        let _buffer_indices = GlBuffer::new_element_array_buffer(gl);
         _buffer_indices.bind();
         let line_indices: [[i32; 2]; 12] = [
             [0, 1], [1, 2], [2, 3], [3, 0],     // front quad
@@ -85,27 +86,28 @@ impl BoxDrawer {
             [4, 0], [3, 7],                     // left quad
         ];
         unsafe {
-            gl::BufferData(
-                gl::ELEMENT_ARRAY_BUFFER,
+            gl.BufferData(
+                opengl::ELEMENT_ARRAY_BUFFER,
                 (line_indices.len() * 2 * mem::size_of::<i32>()) as GLsizeiptr,
                 mem::transmute(&line_indices[0]),
-                gl::STATIC_DRAW,
+                opengl::STATIC_DRAW,
             );
         }
 
         unsafe {
-            let pos_attr = gl::GetAttribLocation(outline_program.id, c_str!("position"));
-            gl::EnableVertexAttribArray(pos_attr as GLuint);
-            gl::VertexAttribPointer(
+            let pos_attr = gl.GetAttribLocation(outline_program.id, c_str!("position"));
+            gl.EnableVertexAttribArray(pos_attr as GLuint);
+            gl.VertexAttribPointer(
                 pos_attr as GLuint,
                 3,
-                gl::FLOAT,
-                gl::FALSE,
+                opengl::FLOAT,
+                opengl::FALSE,
                 3 * mem::size_of::<f32>() as i32,
                 ptr::null(),
             );
         }
         BoxDrawer {
+            gl,
             outline_program,
             u_transform,
             u_color,
@@ -120,16 +122,16 @@ impl BoxDrawer {
         self.vertex_array.bind();
 
         unsafe {
-            gl::UseProgram(self.outline_program.id);
-            gl::UniformMatrix4fv(self.u_transform, 1, false as GLboolean, transform.as_ptr());
-            gl::Uniform4f(
+            self.gl.UseProgram(self.outline_program.id);
+            self.gl.UniformMatrix4fv(self.u_transform, 1, false as GLboolean, transform.as_ptr());
+            self.gl.Uniform4f(
                 self.u_color,
                 color.red,
                 color.green,
                 color.blue,
                 color.alpha,
             );
-            gl::DrawElements(gl::LINES, 24, gl::UNSIGNED_INT, ptr::null());
+            self.gl.DrawElements(opengl::LINES, 24, opengl::UNSIGNED_INT, ptr::null());
         }
     }
 

--- a/sdl_viewer/src/camera.rs
+++ b/sdl_viewer/src/camera.rs
@@ -14,8 +14,7 @@
 
 use cgmath::{Angle, Decomposed, Deg, InnerSpace, Matrix4, One, Quaternion, Rad, Rotation,
              Rotation3, Transform, Vector3, Zero};
-
-use gl;
+use opengl;
 use std::f32;
 
 // Constructs a projection matrix. Math lifted from ThreeJS.
@@ -85,7 +84,7 @@ pub struct Camera {
 }
 
 impl Camera {
-    pub fn new(width: i32, height: i32) -> Self {
+    pub fn new(gl: &opengl::Gl, width: i32, height: i32) -> Self {
         let mut camera = Camera {
             movement_speed: 1.5,
             moving_backward: false,
@@ -108,17 +107,17 @@ impl Camera {
             width: 0,
             height: 0,
         };
-        camera.set_size(width, height);
+        camera.set_size(gl, width, height);
         camera
     }
 
-    pub fn set_size(&mut self, width: i32, height: i32) {
+    pub fn set_size(&mut self, gl: &opengl::Gl, width: i32, height: i32) {
         self.width = width;
         self.height = height;
         self.projection_matrix =
             make_projection_matrix(0.1, 10000., Deg(45.), 1., width as f32 / height as f32);
         unsafe {
-            gl::Viewport(0, 0, width, height);
+            gl.Viewport(0, 0, width, height);
         }
     }
 

--- a/sdl_viewer/src/glhelper.rs
+++ b/sdl_viewer/src/glhelper.rs
@@ -18,27 +18,27 @@
 // This code here was extracted from the glhelper crate. We could not depend on it directly, since
 // we generate our own gl module which cannot be easily injected.
 
-use gl;
-use gl::types::{GLchar, GLenum, GLint, GLuint};
+use opengl;
+use opengl::types::{GLchar, GLenum, GLint, GLuint};
 use std::ffi::CString;
 use std::ptr;
 use std::str;
 
-pub fn compile_shader(code: &str, kind: GLenum) -> GLuint {
+pub fn compile_shader(gl: &opengl::Gl, code: &str, kind: GLenum) -> GLuint {
     let shader;
     unsafe {
-        shader = gl::CreateShader(kind);
+        shader = gl.CreateShader(kind);
         let c_str = CString::new(code.as_bytes()).unwrap();
-        gl::ShaderSource(shader, 1, &c_str.as_ptr(), ptr::null());
-        gl::CompileShader(shader);
-        let mut status = gl::FALSE as GLint;
-        gl::GetShaderiv(shader, gl::COMPILE_STATUS, &mut status);
-        if status != (gl::TRUE as GLint) {
+        gl.ShaderSource(shader, 1, &c_str.as_ptr(), ptr::null());
+        gl.CompileShader(shader);
+        let mut status = opengl::FALSE as GLint;
+        gl.GetShaderiv(shader, opengl::COMPILE_STATUS, &mut status);
+        if status != (opengl::TRUE as GLint) {
             let mut len = 0;
-            gl::GetShaderiv(shader, gl::INFO_LOG_LENGTH, &mut len);
+            gl.GetShaderiv(shader, opengl::INFO_LOG_LENGTH, &mut len);
             let mut buf = Vec::with_capacity(len as usize);
             buf.set_len((len as usize) - 1); // subtract 1 to skip the trailing null character
-            gl::GetShaderInfoLog(
+            gl.GetShaderInfoLog(
                 shader,
                 len,
                 ptr::null_mut(),
@@ -53,23 +53,23 @@ pub fn compile_shader(code: &str, kind: GLenum) -> GLuint {
     shader
 }
 
-pub fn link_program(vertex_shader_id: GLuint, fragment_shader_id: GLuint) -> GLuint {
+pub fn link_program(gl: &opengl::Gl, vertex_shader_id: GLuint, fragment_shader_id: GLuint) -> GLuint {
     unsafe {
-        let program = gl::CreateProgram();
-        gl::AttachShader(program, vertex_shader_id);
-        gl::AttachShader(program, fragment_shader_id);
-        gl::LinkProgram(program);
-        gl::DetachShader(program, vertex_shader_id);
-        gl::DetachShader(program, fragment_shader_id);
+        let program = gl.CreateProgram();
+        gl.AttachShader(program, vertex_shader_id);
+        gl.AttachShader(program, fragment_shader_id);
+        gl.LinkProgram(program);
+        gl.DetachShader(program, vertex_shader_id);
+        gl.DetachShader(program, fragment_shader_id);
 
-        let mut status = gl::FALSE as GLint;
-        gl::GetProgramiv(program, gl::LINK_STATUS, &mut status);
-        if status != (gl::TRUE as GLint) {
+        let mut status = opengl::FALSE as GLint;
+        gl.GetProgramiv(program, opengl::LINK_STATUS, &mut status);
+        if status != (opengl::TRUE as GLint) {
             let mut len: GLint = 0;
-            gl::GetProgramiv(program, gl::INFO_LOG_LENGTH, &mut len);
+            gl.GetProgramiv(program, opengl::INFO_LOG_LENGTH, &mut len);
             let mut buf = Vec::with_capacity(len as usize);
             buf.set_len((len as usize) - 1); // subtract 1 to skip the trailing null character
-            gl::GetProgramInfoLog(
+            gl.GetProgramInfoLog(
                 program,
                 len,
                 ptr::null_mut(),

--- a/sdl_viewer/src/graphic.rs
+++ b/sdl_viewer/src/graphic.rs
@@ -14,100 +14,102 @@
 
 //! Higher level abstractions around core OpenGL concepts.
 
-use gl;
-use gl::types::GLuint;
+use opengl::{self, Gl};
+use opengl::types::GLuint;
 use glhelper::{compile_shader, link_program};
 use std::str;
 
-pub struct GlProgram {
+pub struct GlProgram<'a> {
+    pub gl: &'a Gl,
     pub id: GLuint,
 }
 
-impl GlProgram {
-    pub fn new(vertex_shader: &str, fragment_shader: &str) -> Self {
-        let vertex_shader_id = compile_shader(vertex_shader, gl::VERTEX_SHADER);
-        let fragment_shader_id = compile_shader(fragment_shader, gl::FRAGMENT_SHADER);
-        let id = link_program(vertex_shader_id, fragment_shader_id);
+impl<'a> GlProgram<'a> {
+    pub fn new(gl: &'a opengl::Gl, vertex_shader: &str, fragment_shader: &str) -> Self {
+        let vertex_shader_id = compile_shader(gl, vertex_shader, opengl::VERTEX_SHADER);
+        let fragment_shader_id = compile_shader(gl, fragment_shader, opengl::FRAGMENT_SHADER);
+        let id = link_program(gl, vertex_shader_id, fragment_shader_id);
 
         // TODO(hrapp): Pull out some saner abstractions around program compilation.
         unsafe {
-            gl::DeleteShader(vertex_shader_id);
-            gl::DeleteShader(fragment_shader_id);
+            gl.DeleteShader(vertex_shader_id);
+            gl.DeleteShader(fragment_shader_id);
         }
-
-        GlProgram { id }
+        GlProgram { gl, id }
     }
 }
 
-impl Drop for GlProgram {
+impl<'a> Drop for GlProgram<'a> {
     fn drop(&mut self) {
         unsafe {
-            gl::DeleteProgram(self.id);
+            self.gl.DeleteProgram(self.id);
         }
     }
 }
 
-pub struct GlBuffer {
+pub struct GlBuffer<'a> {
+    gl: &'a Gl,
     id: GLuint,
     buffer_type: GLuint,
 }
 
-impl GlBuffer {
-    pub fn new_array_buffer() -> Self {
+impl<'a> GlBuffer<'a> {
+    pub fn new_array_buffer(gl: &'a opengl::Gl) -> Self {
         let mut id = 0;
         unsafe {
-            gl::GenBuffers(1, &mut id);
+            gl.GenBuffers(1, &mut id);
         }
-        GlBuffer { id, buffer_type: gl::ARRAY_BUFFER }
+        GlBuffer { gl, id, buffer_type: opengl::ARRAY_BUFFER }
     }
 
-    pub fn new_element_array_buffer() -> Self {
+    pub fn new_element_array_buffer(gl: &'a opengl::Gl) -> Self {
         let mut id = 0;
         unsafe {
-            gl::GenBuffers(1, &mut id);
+            gl.GenBuffers(1, &mut id);
         }
-        GlBuffer { id, buffer_type: gl::ELEMENT_ARRAY_BUFFER }
+        GlBuffer { gl, id, buffer_type: opengl::ELEMENT_ARRAY_BUFFER }
     }
 
     pub fn bind(&self) {
         unsafe {
-            gl::BindBuffer(self.buffer_type, self.id);
+            self.gl.BindBuffer(self.buffer_type, self.id);
         }
     }
 }
 
-impl Drop for GlBuffer {
+impl<'a> Drop for GlBuffer<'a> {
     fn drop(&mut self) {
         unsafe {
-            gl::DeleteBuffers(1, &self.id);
+            self.gl.DeleteBuffers(1, &self.id);
         }
     }
 }
 
-pub struct GlVertexArray {
+pub struct GlVertexArray<'a> {
+    gl: &'a Gl,
     id: GLuint,
 }
 
-impl GlVertexArray {
-    pub fn new() -> Self {
+impl<'a> GlVertexArray<'a> {
+    pub fn new(gl: &'a Gl) -> Self {
         let mut id = 0;
         unsafe {
-            gl::GenVertexArrays(1, &mut id);
+            gl.GenVertexArrays(1, &mut id);
         }
-        GlVertexArray { id }
+        GlVertexArray { gl, id }
     }
 
     pub fn bind(&self) {
         unsafe {
-            gl::BindVertexArray(self.id);
+            self.gl.BindVertexArray(self.id);
         }
     }
 }
 
-impl Drop for GlVertexArray {
+impl<'a> Drop for GlVertexArray<'a> {
     fn drop(&mut self) {
         unsafe {
-            gl::DeleteVertexArrays(1, &self.id);
+            self.gl.DeleteVertexArrays(1, &self.id);
         }
     }
 }

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -27,7 +27,7 @@ mod glhelper;
 mod camera;
 
 #[allow(non_upper_case_globals)]
-pub mod gl {
+pub mod opengl {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 

--- a/sdl_viewer/src/main.rs
+++ b/sdl_viewer/src/main.rs
@@ -28,10 +28,10 @@ use rand::{Rng, thread_rng};
 use sdl2::event::{Event, WindowEvent};
 use sdl2::keyboard::Scancode;
 use sdl2::video::GLProfile;
-use sdl_viewer::{Camera, gl};
+use sdl_viewer::{Camera, opengl};
+use sdl_viewer::opengl::types::{GLboolean, GLint, GLsizeiptr, GLuint};
 use sdl_viewer::box_drawer::BoxDrawer;
 use sdl_viewer::color::YELLOW;
-use sdl_viewer::gl::types::{GLboolean, GLint, GLsizeiptr, GLuint};
 use sdl_viewer::graphic::{GlBuffer, GlProgram, GlVertexArray};
 use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry;
@@ -56,8 +56,8 @@ fn reshuffle(new_order: &[usize], old_data: Vec<u8>, bytes_per_vertex: usize) ->
     new_data
 }
 
-struct NodeDrawer {
-    program: GlProgram,
+struct NodeDrawer<'a> {
+    program: GlProgram<'a>,
 
     // Uniforms locations.
     u_world_to_gl: GLint,
@@ -67,22 +67,22 @@ struct NodeDrawer {
     u_min: GLint,
 }
 
-impl NodeDrawer {
-    fn new() -> Self {
-        let program = GlProgram::new(VERTEX_SHADER, FRAGMENT_SHADER);
+impl<'a> NodeDrawer<'a> {
+    fn new(gl: &'a opengl::Gl) -> Self {
+        let program = GlProgram::new(gl, VERTEX_SHADER, FRAGMENT_SHADER);
         let u_world_to_gl;
         let u_edge_length;
         let u_size;
         let u_gamma;
         let u_min;
         unsafe {
-            gl::UseProgram(program.id);
+            gl.UseProgram(program.id);
 
-            u_world_to_gl = gl::GetUniformLocation(program.id, c_str!("world_to_gl"));
-            u_edge_length = gl::GetUniformLocation(program.id, c_str!("edge_length"));
-            u_size = gl::GetUniformLocation(program.id, c_str!("size"));
-            u_gamma = gl::GetUniformLocation(program.id, c_str!("gamma"));
-            u_min = gl::GetUniformLocation(program.id, c_str!("min"));
+            u_world_to_gl = gl.GetUniformLocation(program.id, c_str!("world_to_gl"));
+            u_edge_length = gl.GetUniformLocation(program.id, c_str!("edge_length"));
+            u_size = gl.GetUniformLocation(program.id, c_str!("size"));
+            u_gamma = gl.GetUniformLocation(program.id, c_str!("gamma"));
+            u_min = gl.GetUniformLocation(program.id, c_str!("min"));
         }
         NodeDrawer {
             program,
@@ -94,56 +94,57 @@ impl NodeDrawer {
         }
     }
 
-    fn update_world_to_gl(&self, matrix: &Matrix4<f32>) {
+    fn update_world_to_gl(&self, gl: &opengl::Gl, matrix: &Matrix4<f32>) {
+        // NOCOM(#sirver): use program.gl?
         unsafe {
-            gl::UseProgram(self.program.id);            
-            gl::UniformMatrix4fv(self.u_world_to_gl, 1, false as GLboolean, matrix.as_ptr());
+            gl.UseProgram(self.program.id);            
+            gl.UniformMatrix4fv(self.u_world_to_gl, 1, false as GLboolean, matrix.as_ptr());
         }
     }
 
-    fn draw(&self, node_view: &NodeView, level_of_detail: i32, point_size: f32, gamma: f32) -> i64 {
+    fn draw(&self, gl: &opengl::Gl, node_view: &NodeView, level_of_detail: i32, point_size: f32, gamma: f32) -> i64 {
         node_view.vertex_array.bind();
         let num_points = node_view
             .meta
             .num_points_for_level_of_detail(level_of_detail);
         unsafe {
-            gl::UseProgram(self.program.id);
-            gl::Enable(gl::PROGRAM_POINT_SIZE);
-            gl::Enable(gl::DEPTH_TEST);
+            gl.UseProgram(self.program.id);
+            gl.Enable(opengl::PROGRAM_POINT_SIZE);
+            gl.Enable(opengl::DEPTH_TEST);
 
-            gl::Uniform1f(
+            gl.Uniform1f(
                 self.u_edge_length,
                 node_view.meta.bounding_cube.edge_length(),
             );
-            gl::Uniform1f( self.u_size, point_size);
-            gl::Uniform1f( self.u_gamma, gamma);
-            gl::Uniform3fv(self.u_min, 1, node_view.meta.bounding_cube.min().as_ptr());
+            gl.Uniform1f( self.u_size, point_size);
+            gl.Uniform1f( self.u_gamma, gamma);
+            gl.Uniform3fv(self.u_min, 1, node_view.meta.bounding_cube.min().as_ptr());
 
-            gl::DrawArrays(gl::POINTS, 0, num_points as i32);
+            gl.DrawArrays(opengl::POINTS, 0, num_points as i32);
 
-            gl::Disable(gl::PROGRAM_POINT_SIZE);
+            gl.Disable(opengl::PROGRAM_POINT_SIZE);
         }
         num_points
     }
 }
 
-struct NodeView {
+struct NodeView<'a> {
     meta: octree::NodeMeta,
 
     // The buffers are bound by 'vertex_array', so we never refer to them. But they must outlive
     // this 'NodeView'.
-    vertex_array: GlVertexArray,
-    _buffer_position: GlBuffer,
-    _buffer_color: GlBuffer,
+    vertex_array: GlVertexArray<'a>,
+    _buffer_position: GlBuffer<'a>,
+    _buffer_color: GlBuffer<'a>,
 }
 
-impl NodeView {
-    fn new(program: &GlProgram, node_data: octree::NodeData) -> Self {
+impl<'a> NodeView<'a> {
+    fn new(program: &'a GlProgram, node_data: octree::NodeData) -> Self {
         unsafe {
-            gl::UseProgram(program.id);
+            program.gl.UseProgram(program.id);
         }
 
-        let vertex_array = GlVertexArray::new();
+        let vertex_array = GlVertexArray::new(program.gl);
         vertex_array.bind();
 
         // We draw the points in random order. This allows us to only draw the first N if we want
@@ -163,27 +164,27 @@ impl NodeView {
         );
         let color = reshuffle(&indices, node_data.color, 3);
 
-        let buffer_position = GlBuffer::new_array_buffer();
-        let buffer_color = GlBuffer::new_array_buffer();
+        let buffer_position = GlBuffer::new_array_buffer(program.gl);
+        let buffer_color = GlBuffer::new_array_buffer(program.gl);
 
         unsafe {
             buffer_position.bind();
             let (normalize, data_type) = match node_data.meta.position_encoding {
-                octree::PositionEncoding::Uint8 => (true, gl::UNSIGNED_BYTE),
-                octree::PositionEncoding::Uint16 => (true, gl::UNSIGNED_SHORT),
-                octree::PositionEncoding::Float32 => (false, gl::FLOAT),
+                octree::PositionEncoding::Uint8 => (true, opengl::UNSIGNED_BYTE),
+                octree::PositionEncoding::Uint16 => (true, opengl::UNSIGNED_SHORT),
+                octree::PositionEncoding::Float32 => (false, opengl::FLOAT),
             };
-            gl::BufferData(
-                gl::ARRAY_BUFFER,
+            program.gl.BufferData(
+                opengl::ARRAY_BUFFER,
                 position.len() as GLsizeiptr,
                 mem::transmute(&position[0]),
-                gl::STATIC_DRAW,
+                opengl::STATIC_DRAW,
             );
 
             // Specify the layout of the vertex data.
-            let pos_attr = gl::GetAttribLocation(program.id, c_str!("position"));
-            gl::EnableVertexAttribArray(pos_attr as GLuint);
-            gl::VertexAttribPointer(
+            let pos_attr = program.gl.GetAttribLocation(program.id, c_str!("position"));
+            program.gl.EnableVertexAttribArray(pos_attr as GLuint);
+            program.gl.VertexAttribPointer(
                 pos_attr as GLuint,
                 3,
                 data_type,
@@ -193,19 +194,19 @@ impl NodeView {
             );
 
             buffer_color.bind();
-            gl::BufferData(
-                gl::ARRAY_BUFFER,
+            program.gl.BufferData(
+                opengl::ARRAY_BUFFER,
                 color.len() as GLsizeiptr,
                 mem::transmute(&color[0]),
-                gl::STATIC_DRAW,
+                opengl::STATIC_DRAW,
             );
-            let color_attr = gl::GetAttribLocation(program.id, c_str!("color"));
-            gl::EnableVertexAttribArray(color_attr as GLuint);
-            gl::VertexAttribPointer(
+            let color_attr = program.gl.GetAttribLocation(program.id, c_str!("color"));
+            program.gl.EnableVertexAttribArray(color_attr as GLuint);
+            program.gl.VertexAttribPointer(
                 color_attr as GLuint,
                 3,
-                gl::UNSIGNED_BYTE,
-                gl::FALSE as GLboolean,
+                opengl::UNSIGNED_BYTE,
+                opengl::FALSE as GLboolean,
                 0,
                 ptr::null(),
             );
@@ -220,8 +221,8 @@ impl NodeView {
 }
 
 // Keeps track of the nodes that were requested in-order and loads then one by one on request.
-struct NodeViewContainer {
-    node_views: HashMap<octree::NodeId, NodeView>,
+struct NodeViewContainer<'a> {
+    node_views: HashMap<octree::NodeId, NodeView<'a>>,
     // The node_ids that the I/O thread is currently loading.
     requested: HashSet<octree::NodeId>,
     // Communication with the I/O thread.
@@ -229,7 +230,7 @@ struct NodeViewContainer {
     node_data_receiver: Receiver<(octree::NodeId, octree::NodeData)>,
 }
 
-impl NodeViewContainer {
+impl<'a> NodeViewContainer<'a> {
     fn new(octree: Arc<octree::Octree>) -> Self {
         // We perform I/O in a separate thread in order to not block the main thread while loading.
         // Data sharing is done through channels.
@@ -240,11 +241,11 @@ impl NodeViewContainer {
             for node_id in node_id_receiver.into_iter() {
                 // We always request nodes at full resolution (i.e. not subsampled by the backend), because
                 // we can just as effectively subsample the number of points we draw in the client.
-                const ALL_POINTS_LOD: i32 = 1;                
+                const ALL_POINTS_LOD: i32 = 1;
                 let node_data = octree.get_node_data(&node_id, ALL_POINTS_LOD).unwrap();
                 // TODO(hrapp): reshuffle
                 node_data_sender.send((node_id, node_data)).unwrap();
-            } 
+            }
         });
         NodeViewContainer {
             node_views: HashMap::new(),
@@ -256,7 +257,7 @@ impl NodeViewContainer {
 
     // Returns the 'NodeView' for 'node_id' if it is already loaded, otherwise returns None, but
     // requested the node for loading in the I/O thread
-    fn get_or_request(&mut self, node_id: &octree::NodeId, program: &GlProgram) -> Option<&NodeView> {
+    fn get_or_request(&mut self, node_id: &octree::NodeId, program: &'a GlProgram) -> Option<&NodeView> {
         while let Ok((node_id, node_data)) = self.node_data_receiver.try_recv() {
             // Put loaded node into hash map.
             self.requested.remove(&node_id);
@@ -269,7 +270,7 @@ impl NodeViewContainer {
             Entry::Vacant(_) => {
                 // Limit the number of requested nodes because after a camera move
                 // requested nodes might not be in the frustum anymore.
-                if !self.requested.contains(&node_id) && self.requested.len() < 10 {  
+                if !self.requested.contains(&node_id) && self.requested.len() < 10 {
                     self.requested.insert(*node_id);
                     self.node_id_sender.send(*node_id).unwrap();
                 }
@@ -338,22 +339,22 @@ fn main() {
 
     assert_eq!(gl_attr.context_profile(), GLProfile::Core);
 
-    gl::load_with(
+    let gl = opengl::Gl::load_with(
         |s| {
             let ptr = video_subsystem.gl_get_proc_address(s);
             unsafe { std::mem::transmute(ptr) }
         }
     );
 
-    let node_drawer = NodeDrawer::new();
+    let node_drawer = NodeDrawer::new(&gl);
     let mut node_views = NodeViewContainer::new(octree.clone());
     let mut visible_nodes = Vec::new();
 
-    let box_drawer = BoxDrawer::new();
+    let box_drawer = BoxDrawer::new(&gl);
     let octree_box_color = YELLOW;
     let mut show_octree_nodes = false;
 
-    let mut camera = Camera::new(WINDOW_WIDTH, WINDOW_HEIGHT);
+    let mut camera = Camera::new(&gl, WINDOW_WIDTH, WINDOW_HEIGHT);
 
     let mut events = ctx.event_pump().unwrap();
     let mut num_frames = 0;
@@ -406,7 +407,7 @@ fn main() {
                     camera.mouse_wheel(y);
                 }
                 Event::Window { win_event: WindowEvent::SizeChanged(w, h), .. } => {
-                    camera.set_size(w, h);
+                    camera.set_size(&gl, w, h);
                 }
                 _ => (),
             }
@@ -414,7 +415,7 @@ fn main() {
 
         if camera.update() {
             use_level_of_detail = true;
-            node_drawer.update_world_to_gl(&camera.get_world_to_gl());
+            node_drawer.update_world_to_gl(&gl, &camera.get_world_to_gl());
             visible_nodes = octree.get_visible_nodes(
                 &camera.get_world_to_gl(),
                 camera.width,
@@ -435,14 +436,15 @@ fn main() {
         let mut num_points_drawn = 0;
         let mut num_nodes_drawn = 0;
         unsafe {
-            gl::ClearColor(0., 0., 0., 1.);
-            gl::Clear(gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT);
+            gl.ClearColor(0., 0., 0., 1.);
+            gl.Clear(opengl::COLOR_BUFFER_BIT | opengl::DEPTH_BUFFER_BIT);
 
             for visible_node in &visible_nodes {
                 // TODO(sirver): Track a point budget here when moving, so that FPS never drops too
                 // low.
                 if let Some(view) = node_views.get_or_request(&visible_node.id, &node_drawer.program) {
                     num_points_drawn += node_drawer.draw(
+                        &gl,
                         view,
                         if use_level_of_detail {
                             visible_node.level_of_detail

--- a/web_viewer/Cargo.lock
+++ b/web_viewer/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.7.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -580,7 +580,7 @@ dependencies = [
  "bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgmath 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1071,7 +1071,7 @@ dependencies = [
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
-"checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
+"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum fixedbitset 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fcf4412e2d11115c5ed81c2fbdaba8028de0c92553497aa771fc5f4e0c5c8793"
 "checksum flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "36df0166e856739905cd3d7e0b210fe818592211a008862599845e012d8d304c"
 "checksum gcc 0.3.49 (registry+https://github.com/rust-lang/crates.io-index)" = "9be730064c122681712957ba1a9abaf082150be8aaf94526a805d900015b65b9"


### PR DESCRIPTION
Instead of standalone functions, we now load the GL bindings into a struct. This should make it easier to move all opengl related functionality into one submodule, which again should make it simpler to swap it out against other functionality (e.g. WebGL).