### PR TITLE
Small refactorings to clear up responsibility of some structs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ error-chain = "0.11.0"
 num = "0.1.36"
 num-traits = "0.1.36"
 pbr = "1.0.0-alpha.1"
+protobuf = "1.4.3"
 scoped-pool = "^0.1"
 walkdir = "^0.1.5"
-protobuf = "1.4.3"
 
 [profile.release]
 lto = true

--- a/sdl_viewer/Cargo.toml
+++ b/sdl_viewer/Cargo.toml
@@ -22,11 +22,11 @@ gl_generator = "0.8.0"
 
 [dependencies]
 cgmath = "^0.14.0"
+clap = "^2.6.0"
+lru-cache = "^0.1.1"
 rand = "0.3.15"
 sdl2 = "0.30.0-beta"
 time = "^0.1.35"
-clap = "^2.6.0"
-lru-cache = "^0.1.1"
 
 [dependencies.point_viewer]
 path = ".."

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -33,7 +33,7 @@ pub mod opengl {
 
 pub mod box_drawer;
 pub mod color;
-// TODO(thomasschiwietz): Use 'Color' in the 'Point' struct in point_cloud_viewer/src/lib.rs (top level crate)
+// TODO(thomasschiwietz): Use 'Color' in the 'Point' struct in src/lib.rs (top level crate)
 // instead of using single variables for r,g,b
 
 pub mod graphic;

--- a/src/proto.proto
+++ b/src/proto.proto
@@ -16,7 +16,7 @@
 
 syntax = "proto3";
 
-package point_cloud_viewer.proto;
+package point_viewer.proto;
 
 message Vector3f {
   float x = 1;

--- a/web_viewer/Cargo.toml
+++ b/web_viewer/Cargo.toml
@@ -21,10 +21,10 @@ version = "0.1.0"
 byteorder = "^0.5.3"
 clap = "^2.6.0"
 iron = "^0.3.0"
+json = "0.11.3"
 router = "^0.1.1"
 time = "^0.1.35"
 urlencoded = "^0.3.0"
-json = "0.11.3"
 
 [dependencies.point_viewer]
 path = ".."


### PR DESCRIPTION
- Make NodeId::get_stem() public.
- Consistent naming: everything is named like the crate name now.
- Remove stem from NodeMeta, as not every node has a on-disk representation.
- Sort Cargo.toml files alphabetically.