### PR TITLE
Make beta required to pass on travis again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rust:
   - nightly
 matrix:
   allow_failures:
-    - rust: beta
     - rust: nightly
 
 addons:


### PR DESCRIPTION
Upstream bug https://github.com/rust-lang/rust/issues/47175 is fixed, so we enable beta again as required for passing.