### PR TITLE
Store meta information of all nodes in root meta.pb

### DIFF
--- a/src/bin/build_octree.rs
+++ b/src/bin/build_octree.rs
@@ -307,27 +307,30 @@ fn main() {
 
     let (bounding_box, num_points) = find_bounding_box(&input);
 
-    let mut meta = proto::Meta::new();
-    meta.mut_bounding_box()
-        .mut_min()
-        .set_x(bounding_box.min().x);
-    meta.mut_bounding_box()
-        .mut_min()
-        .set_y(bounding_box.min().y);
-    meta.mut_bounding_box()
-        .mut_min()
-        .set_z(bounding_box.min().z);
-    meta.mut_bounding_box()
-        .mut_max()
-        .set_x(bounding_box.max().x);
-    meta.mut_bounding_box()
-        .mut_max()
-        .set_y(bounding_box.max().y);
-    meta.mut_bounding_box()
-        .mut_max()
-        .set_z(bounding_box.max().z);
-    meta.set_resolution(resolution);
-    meta.set_version(octree::CURRENT_VERSION);
+    let mut meta = {
+        let mut meta = proto::Meta::new();
+        meta.mut_bounding_box()
+            .mut_min()
+            .set_x(bounding_box.min().x);
+        meta.mut_bounding_box()
+            .mut_min()
+            .set_y(bounding_box.min().y);
+        meta.mut_bounding_box()
+            .mut_min()
+            .set_z(bounding_box.min().z);
+        meta.mut_bounding_box()
+            .mut_max()
+            .set_x(bounding_box.max().x);
+        meta.mut_bounding_box()
+            .mut_max()
+            .set_y(bounding_box.max().y);
+        meta.mut_bounding_box()
+            .mut_max()
+            .set_z(bounding_box.max().z);
+        meta.set_resolution(resolution);
+        meta.set_version(octree::CURRENT_VERSION);
+        meta
+    };
 
     // Ignore errors, maybe directory is already there.
     let _ = fs::create_dir(output_directory);

--- a/src/bin/build_octree.rs
+++ b/src/bin/build_octree.rs
@@ -307,6 +307,9 @@ fn main() {
 
     let (bounding_box, num_points) = find_bounding_box(&input);
 
+    // Ignore errors, maybe directory is already there.
+    let _ = fs::create_dir(output_directory);
+
     let mut meta = {
         let mut meta = proto::Meta::new();
         meta.mut_bounding_box()
@@ -331,9 +334,6 @@ fn main() {
         meta.set_version(octree::CURRENT_VERSION);
         meta
     };
-
-    // Ignore errors, maybe directory is already there.
-    let _ = fs::create_dir(output_directory);
 
     println!("Creating octree structure.");
     let pool = Pool::new(10);

--- a/src/bin/build_octree.rs
+++ b/src/bin/build_octree.rs
@@ -159,7 +159,7 @@ fn subsample_children_into(
     output_directory: &Path,
     node: &octree::Node,
     resolution: f64,
-    nodes_sender: &mpsc::Sender<(octree::NodeId, octree::NodeMeta)>,    
+    finished_node_sender: &mpsc::Sender<(octree::NodeId, octree::NodeMeta)>,    
 ) -> Result<()> {
     let mut parent_writer = octree::NodeWriter::new(output_directory, &node, resolution);
     println!("Creating {} from subsampling children.", node.id);
@@ -185,7 +185,7 @@ fn subsample_children_into(
             }
         }
         if child_writer.num_written() > 0 {
-            nodes_sender.send(
+            finished_node_sender.send(
                 (child.id, octree::NodeMeta {
                     num_points: child_writer.num_written(),
                     position_encoding: octree::PositionEncoding::new(&child.bounding_cube, resolution),
@@ -196,7 +196,7 @@ fn subsample_children_into(
     }
     // add root node
     if node.parent().is_none() {
-        nodes_sender.send(
+        finished_node_sender.send(
             (node.id, octree::NodeMeta {
                 num_points: parent_writer.num_written(),
                 position_encoding: octree::PositionEncoding::new(&node.bounding_cube, resolution),

--- a/src/bin/build_octree.rs
+++ b/src/bin/build_octree.rs
@@ -407,7 +407,8 @@ fn main() {
     drop(nodes_sender);
     for (id, node_meta) in nodes_receiver {
         let mut proto = proto::Node::new();
-        proto.set_id(id.to_string());
+        proto.mut_id().set_level(id.level() as i32);
+        proto.mut_id().set_index(id.index() as i64);
         proto.set_num_points(node_meta.num_points);
         proto
             .mut_bounding_cube()

--- a/src/bin/build_octree.rs
+++ b/src/bin/build_octree.rs
@@ -404,8 +404,8 @@ fn main() {
     }
 
     // Add all node meta data to meta.pb
-    // TODO(tschiwietz): How can we make sure not to miss any messages?
-    while let Ok((id, node_meta)) = nodes_receiver.try_recv() {
+    drop(nodes_sender);
+    for (id, node_meta) in nodes_receiver {
         let mut proto = proto::Node::new();
         proto.set_id(id.to_string());
         proto.set_num_points(node_meta.num_points);

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -150,15 +150,15 @@ impl OnDiskOctree {
             )
         };
 
-        println!("node count {}", meta.mut_node_points().len());
+        println!("node count {}", meta.mut_nodes().len());
         let mut nodes = HashMap::new();
-        for node_points in meta.mut_node_points().iter() {
+        for node in meta.mut_nodes().iter() {
             nodes.insert(
-                NodeId::from_str(&node_points.id), 
-                node_points.num_points as u64
+                NodeId::from_str(&node.id), 
+                node.num_points as u64
             );
         }
-        println!("hashmap size {}", meta.mut_node_points().len());
+        // println!("hashmap size {}", meta.mut_node_points().len());
 
         // for entry in walkdir::WalkDir::new(&directory)
         //     .into_iter()

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -241,7 +241,7 @@ impl Octree for OnDiskOctree {
     fn get_node_data(&self, node_id: &NodeId, level_of_detail: i32) -> Result<NodeData> {
         let stem = node_id.get_stem(&self.directory);
         let meta = {
-            let mut meta = node::NodeMeta::from_disk(&stem)?;
+            let mut meta = self.nodes[node_id].clone();
             meta.num_points = meta.num_points_for_level_of_detail(level_of_detail);
             meta
         };

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -152,7 +152,10 @@ impl OnDiskOctree {
         let mut nodes = HashMap::new();
         for meta in meta.nodes.iter() {
             nodes.insert(
-                NodeId::from_str(&meta.id), 
+                NodeId::from_level_index(
+                    meta.id.as_ref().unwrap().level as u8,
+                    meta.id.as_ref().unwrap().index as usize,
+                ), 
                 NodeMeta {
                     num_points: meta.num_points,
                     position_encoding: PositionEncoding::from_proto(meta.position_encoding)?,

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -128,7 +128,7 @@ impl OnDiskOctree {
             return Err(ErrorKind::InvalidVersion(3).into());
         }
 
-        let mut meta = {
+        let meta = {
             let mut data = Vec::new();
             File::open(&directory.join("meta.pb"))?.read_to_end(&mut data)?;
             protobuf::parse_from_reader::<proto::Meta>(&mut Cursor::new(data))
@@ -140,7 +140,7 @@ impl OnDiskOctree {
         }
 
         let bounding_box = {
-            let bounding_box = meta.bounding_box.clone().unwrap();
+            let bounding_box = meta.bounding_box.unwrap();
             let min = bounding_box.min.unwrap();
             let max = bounding_box.max.unwrap();
             Aabb3f::new(
@@ -150,7 +150,7 @@ impl OnDiskOctree {
         };
 
         let mut nodes = HashMap::new();
-        for meta in meta.mut_nodes().iter() {
+        for meta in meta.nodes.iter() {
             nodes.insert(
                 NodeId::from_str(&meta.id), 
                 NodeMeta {

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -157,8 +157,8 @@ impl OnDiskOctree {
                     num_points: meta.num_points,
                     position_encoding: PositionEncoding::from_proto(meta.position_encoding)?,
                     bounding_cube: {
-                        let proto = meta.bounding_cube.clone().unwrap();
-                        let min = proto.min.unwrap();
+                        let proto = meta.bounding_cube.as_ref().unwrap();
+                        let min = proto.min.as_ref().unwrap();
                         Cube::new(Point3f::new(min.x, min.y, min.z), proto.edge_length)
                     },
                 }

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -91,7 +91,6 @@ fn size_in_pixels(bounding_cube: &Cube, matrix: &Matrix4f, width: i32, height: i
 #[derive(Debug)]
 pub struct OnDiskOctree {
     directory: PathBuf,
-    // Maps from node id to NodeMeta: bounding_box, number of points, PositionEncoding.
     nodes: HashMap<NodeId, NodeMeta>,
     bounding_box: Aabb3f,
 }

--- a/src/octree/node.rs
+++ b/src/octree/node.rs
@@ -347,7 +347,7 @@ pub enum PositionEncoding {
 }
 
 impl PositionEncoding {
-    fn new(bounding_cube: &Cube, resolution: f64) -> PositionEncoding {
+    pub fn new(bounding_cube: &Cube, resolution: f64) -> PositionEncoding {
         let min_bits = (f64::from(bounding_cube.edge_length()) / resolution).log2() as u32 + 1;
         match min_bits {
             0...8 => PositionEncoding::Uint8,

--- a/src/octree/node.rs
+++ b/src/octree/node.rs
@@ -210,7 +210,7 @@ impl Node {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct NodeMeta {
     pub num_points: i64,
     pub position_encoding: PositionEncoding,
@@ -339,7 +339,7 @@ impl InternalIterator for NodeIterator {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PositionEncoding {
     Uint8,
     Uint16,

--- a/src/octree/node.rs
+++ b/src/octree/node.rs
@@ -83,6 +83,10 @@ impl NodeId {
         NodeId { level, index }
     }
 
+    pub fn from_level_index(level: u8, index: usize) -> Self {
+        NodeId { level, index }
+    }
+
     /// Returns the path on disk where the data for this node is saved.
     pub fn get_stem(&self, directory: &Path) -> PathBuf {
         directory.join(&self.to_string())
@@ -121,8 +125,13 @@ impl NodeId {
     }
 
     /// Returns the level of this node in the octree, with 0 being the root.
-    fn level(&self) -> usize {
+    pub fn level(&self) -> usize {
         self.level as usize
+    }
+
+    /// Returns the index of this node at the current level.
+    pub fn index(&self) -> usize {
+        self.index as usize
     }
 }
 

--- a/src/proto.proto
+++ b/src/proto.proto
@@ -34,10 +34,16 @@ message AxisAlignedCuboid {
   Vector3f max = 2;
 }
 
+message NodePoints {
+  string id = 1;
+  int64 num_points = 2;
+}
+
 message Meta {
   int32 version = 1;
   AxisAlignedCuboid bounding_box = 4;
   double resolution = 3;
+  repeated NodePoints node_points = 5;
 }
 
 message Node {

--- a/src/proto.proto
+++ b/src/proto.proto
@@ -34,6 +34,11 @@ message AxisAlignedCuboid {
   Vector3f max = 2;
 }
 
+message NodeId {
+  int32 level = 1;
+  int64 index = 2;
+}
+
 message Node {
   enum PositionEncoding {
     INVALID = 0;
@@ -45,7 +50,7 @@ message Node {
   AxisAlignedCube bounding_cube = 1;
   PositionEncoding position_encoding = 2;
   int64 num_points = 3;
-  string id = 4;
+  NodeId id = 4;
 }
 
 message Meta {

--- a/src/proto.proto
+++ b/src/proto.proto
@@ -34,18 +34,6 @@ message AxisAlignedCuboid {
   Vector3f max = 2;
 }
 
-message NodePoints {
-  string id = 1;
-  int64 num_points = 2;
-}
-
-message Meta {
-  int32 version = 1;
-  AxisAlignedCuboid bounding_box = 4;
-  double resolution = 3;
-  repeated NodePoints node_points = 5;
-}
-
 message Node {
   enum PositionEncoding {
     INVALID = 0;
@@ -57,4 +45,12 @@ message Node {
   AxisAlignedCube bounding_cube = 1;
   PositionEncoding position_encoding = 2;
   int64 num_points = 3;
+  string id = 4;
+}
+
+message Meta {
+  int32 version = 1;
+  AxisAlignedCuboid bounding_box = 4;
+  double resolution = 3;
+  repeated Node nodes = 5;
 }


### PR DESCRIPTION
This pull request is part of fixing #86 

Things to be done in follow up pull requests:
- build_octree: store NodeMeta in HashMap and remove load/store of r*.pb (meta data for each node)
- proto: replace 'repeated' by 'map'
- proto: get rid of bounding_box
- adapt S3Octree