### PR TITLE
No longer reexport basic math types.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
 name = "point_viewer_grpc"
 version = "0.1.0"
 dependencies = [
+ "cgmath 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -865,6 +866,7 @@ name = "web_viewer"
 version = "0.1.0"
 dependencies = [
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cgmath 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -18,6 +18,7 @@ name = "point_viewer_grpc"
 version = "0.1.0"
 
 [dependencies]
+cgmath = "0.16.0"
 clap = "^2.6.0"
 futures = "0.1.17"
 grpcio = "0.2"

--- a/grpc/src/lib.rs
+++ b/grpc/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate cgmath;
 extern crate futures;
 extern crate grpcio;
 extern crate point_viewer;
@@ -20,9 +21,10 @@ extern crate protobuf;
 include!(concat!(env!("OUT_DIR"), "/proto.rs"));
 include!(concat!(env!("OUT_DIR"), "/proto_grpc.rs"));
 
+use cgmath::{Matrix4, Point3};
 use grpcio::{ChannelBuilder, EnvBuilder};
 use point_viewer::errors::*;
-use point_viewer::math::{self, Cube, Matrix4f};
+use point_viewer::math::Cube;
 use point_viewer::octree::{NodeData, NodeId, NodeMeta, Octree, PositionEncoding, UseLod,
                            VisibleNode};
 use proto_grpc::OctreeClient;
@@ -44,7 +46,7 @@ impl GrpcOctree {
 impl Octree for GrpcOctree {
     fn get_visible_nodes(
         &self,
-        projection_matrix: &Matrix4f,
+        projection_matrix: &Matrix4<f32>,
         width: i32,
         height: i32,
         _: UseLod,
@@ -103,7 +105,7 @@ impl Octree for GrpcOctree {
                 num_points: node.num_points,
                 position_encoding: PositionEncoding::from_proto(node.position_encoding).unwrap(),
                 bounding_cube: Cube::new(
-                    math::Point3f::new(
+                    Point3::new(
                         node.get_bounding_cube().get_min().get_x(),
                         node.get_bounding_cube().get_min().get_y(),
                         node.get_bounding_cube().get_min().get_z(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub trait InternalIterator {
 
 #[derive(Debug, Clone)]
 pub struct Point {
-    pub position: math::Vector3f,
+    pub position: cgmath::Vector3<f32>,
     pub r: u8,
     pub g: u8,
     pub b: u8,

--- a/src/math.rs
+++ b/src/math.rs
@@ -12,25 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use cgmath;
-use collision;
-
-pub type Vector2f = cgmath::Vector2<f32>;
-pub type Vector3f = cgmath::Vector3<f32>;
-pub type Matrix4f = cgmath::Matrix4<f32>;
-pub type Point3f = cgmath::Point3<f32>;
-pub type Aabb3f = collision::Aabb3<f32>;
-pub use cgmath::prelude::*;
-pub use collision::Aabb;
+use cgmath::{Point3, Vector3};
+use collision::{Aabb, Aabb3};
 
 #[derive(Debug, Clone)]
 pub struct Cube {
-    min: Point3f,
+    min: Point3<f32>,
     edge_length: f32,
 }
 
 impl Cube {
-    pub fn bounding(aabb: &Aabb3f) -> Self {
+    pub fn bounding(aabb: &Aabb3<f32>) -> Self {
         let edge_length = (aabb.max().x - aabb.min().x)
             .max(aabb.max().y - aabb.min().y)
             .max(aabb.max().z - aabb.min().z);
@@ -40,11 +32,11 @@ impl Cube {
         }
     }
 
-    pub fn to_aabb3(&self) -> Aabb3f {
-        Aabb3f::new(self.min(), self.max())
+    pub fn to_aabb3(&self) -> Aabb3<f32> {
+        Aabb3::new(self.min(), self.max())
     }
 
-    pub fn new(min: Point3f, edge_length: f32) -> Self {
+    pub fn new(min: Point3<f32>, edge_length: f32) -> Self {
         Cube {
             min: min,
             edge_length: edge_length,
@@ -55,12 +47,12 @@ impl Cube {
         self.edge_length
     }
 
-    pub fn min(&self) -> Point3f {
+    pub fn min(&self) -> Point3<f32> {
         self.min
     }
 
-    pub fn max(&self) -> Point3f {
-        Point3f::new(
+    pub fn max(&self) -> Point3<f32> {
+        Point3::new(
             self.min.x + self.edge_length,
             self.min.y + self.edge_length,
             self.min.z + self.edge_length,
@@ -68,10 +60,10 @@ impl Cube {
     }
 
     /// The center of the box.
-    pub fn center(&self) -> Vector3f {
+    pub fn center(&self) -> Vector3<f32> {
         let min = self.min();
         let max = self.max();
-        Vector3f::new(
+        Vector3::new(
             (min.x + max.x) / 2.,
             (min.y + max.y) / 2.,
             (min.z + max.z) / 2.,

--- a/src/octree/node.rs
+++ b/src/octree/node.rs
@@ -14,8 +14,9 @@
 
 use {InternalIterator, Point};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use cgmath::{Point3, Vector3, Zero};
 use errors::*;
-use math::{clamp, Cube, Point3f, Vector3f, Zero};
+use math::{clamp, Cube};
 use num;
 use num_traits;
 use proto;
@@ -173,7 +174,7 @@ impl Node {
     }
 
     /// Returns the ChildId of the child containing 'v'.
-    pub fn get_child_id_containing_point(&self, v: &Vector3f) -> ChildIndex {
+    pub fn get_child_id_containing_point(&self, v: &Vector3<f32>) -> ChildIndex {
         // This is a bit flawed: it is not guaranteed that 'child_bounding_box.contains(&v)' is true
         // using this calculated index due to floating point precision.
         let center = self.bounding_cube.center();
@@ -247,7 +248,7 @@ impl NodeMeta {
             bounding_cube: {
                 let proto = meta.bounding_cube.unwrap();
                 let min = proto.min.unwrap();
-                Cube::new(Point3f::new(min.x, min.y, min.z), proto.edge_length)
+                Cube::new(Point3::new(min.x, min.y, min.z), proto.edge_length)
             },
         })
     }
@@ -283,7 +284,7 @@ impl InternalIterator for NodeIterator {
 
     fn for_each<F: FnMut(&Point)>(mut self, mut f: F) {
         let mut point = Point {
-            position: Vector3f::zero(),
+            position: Vector3::zero(),
             r: 0,
             g: 0,
             b: 0,

--- a/src/ply.rs
+++ b/src/ply.rs
@@ -14,8 +14,8 @@
 
 use {InternalIterator, Point};
 use byteorder::{ByteOrder, LittleEndian};
+use cgmath::Vector3;
 use errors::*;
-use math::Vector3f;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use std::ops::Index;
@@ -389,7 +389,7 @@ impl InternalIterator for PlyIterator {
 
     fn for_each<F: FnMut(&Point)>(mut self, mut func: F) {
         let mut point = Point {
-            position: Vector3f::new(0., 0., 0.),
+            position: Vector3::new(0., 0., 0.),
             r: 255,
             g: 255,
             b: 255,

--- a/src/pts.rs
+++ b/src/pts.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use {InternalIterator, Point};
-use math::Vector3f;
+use cgmath::Vector3;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -51,7 +51,7 @@ impl InternalIterator for PtsIterator {
                 continue;
             }
             let p = Point {
-                position: Vector3f::new(
+                position: Vector3::new(
                     parts[0].parse::<f32>().unwrap(),
                     parts[1].parse::<f32>().unwrap(),
                     parts[2].parse::<f32>().unwrap(),

--- a/web_viewer/Cargo.toml
+++ b/web_viewer/Cargo.toml
@@ -19,6 +19,7 @@ version = "0.1.0"
 
 [dependencies]
 byteorder = "^0.5.3"
+cgmath = "0.16.0"
 clap = "^2.6.0"
 iron = "^0.3.0"
 json = "0.11.3"

--- a/web_viewer/src/main.rs
+++ b/web_viewer/src/main.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 extern crate byteorder;
+extern crate cgmath;
 #[macro_use]
 extern crate clap;
 extern crate iron;
@@ -23,9 +24,9 @@ extern crate time;
 extern crate urlencoded;
 
 use byteorder::{LittleEndian, WriteBytesExt};
+use cgmath::Matrix4;
 use iron::mime::Mime;
 use iron::prelude::*;
-use point_viewer::math::Matrix4f;
 use point_viewer::octree::{self, Octree};
 use router::Router;
 use std::io::Read;
@@ -72,7 +73,7 @@ impl iron::Handler for VisibleNodes {
                 .split(',')
                 .map(|s| s.parse::<f32>().unwrap())
                 .collect();
-            Matrix4f::new(
+            Matrix4::new(
                 e[0],
                 e[1],
                 e[2],


### PR DESCRIPTION
Makes usage of cgmath and collision explicit.
Also removes one instance of glob importing proto::*