### PR TITLE
Format TypeScript and JavaScript using Prettier (prettier.io)

### DIFF
--- a/xray/client/control.ts
+++ b/xray/client/control.ts
@@ -14,7 +14,7 @@
 
 'use strict';
 
-import * as THREE from "three";
+import * as THREE from 'three';
 
 enum MouseState {
   NONE,
@@ -33,19 +33,34 @@ export class Maps2DController {
   private moveUp: boolean;
   private viewHasChanged: boolean;
 
-  constructor(private camera: THREE.OrthographicCamera, private domElement: Element) {
+  constructor(
+    private camera: THREE.OrthographicCamera,
+    private domElement: Element
+  ) {
     this.camera.zoom = 0.2;
     this.mouseState = MouseState.NONE;
     this.dragStart = new THREE.Vector2(0, 0);
 
     window.addEventListener(
-      'keydown', event => this.onKeyDown(<KeyboardEvent>event), false);
+      'keydown',
+      (event) => this.onKeyDown(<KeyboardEvent>event),
+      false
+    );
     window.addEventListener(
-      'keyup', event => this.onKeyUp(<KeyboardEvent>event), false);
+      'keyup',
+      (event) => this.onKeyUp(<KeyboardEvent>event),
+      false
+    );
     window.addEventListener(
-      'mousewheel', event => this.onMouseWheel(<WheelEvent>event), false);
+      'mousewheel',
+      (event) => this.onMouseWheel(<WheelEvent>event),
+      false
+    );
     this.domElement.addEventListener(
-      'mousedown', event => this.onMouseDown(<MouseEvent>event), false);
+      'mousedown',
+      (event) => this.onMouseDown(<MouseEvent>event),
+      false
+    );
   }
 
   public update(): boolean {
@@ -81,23 +96,23 @@ export class Maps2DController {
 
   private setMoving(keyCode: string, state: boolean) {
     switch (keyCode) {
-      case "ArrowUp":
-      case "KeyW":
+      case 'ArrowUp':
+      case 'KeyW':
         this.moveUp = state;
         break;
 
-      case "ArrowDown":
-      case "KeyS":
+      case 'ArrowDown':
+      case 'KeyS':
         this.moveDown = state;
         break;
 
-      case "ArrowLeft":
-      case "KeyA":
+      case 'ArrowLeft':
+      case 'KeyA':
         this.moveLeft = state;
         break;
 
-      case "ArrowRight":
-      case "KeyD":
+      case 'ArrowRight':
+      case 'KeyD':
         this.moveRight = state;
         break;
     }
@@ -119,17 +134,29 @@ export class Maps2DController {
       this.mouseState = MouseState.DRAG;
       this.dragStart.set(event.clientX, event.clientY);
       this.domElement.addEventListener(
-        'mousemove', event => this.onMouseMove(<MouseEvent>event), false);
+        'mousemove',
+        (event) => this.onMouseMove(<MouseEvent>event),
+        false
+      );
       this.domElement.addEventListener(
-        'mouseup', event => this.onMouseUp(<MouseEvent>event), false);
+        'mouseup',
+        (event) => this.onMouseUp(<MouseEvent>event),
+        false
+      );
     }
   }
 
   private onMouseUp(event: MouseEvent) {
     this.domElement.removeEventListener(
-      'mousemove', event => this.onMouseMove(<MouseEvent>event), false);
+      'mousemove',
+      (event) => this.onMouseMove(<MouseEvent>event),
+      false
+    );
     this.domElement.removeEventListener(
-      'mouseup', event => this.onMouseUp(<MouseEvent>event), false);
+      'mouseup',
+      (event) => this.onMouseUp(<MouseEvent>event),
+      false
+    );
     this.mouseState = MouseState.NONE;
   }
 
@@ -149,14 +176,16 @@ export class Maps2DController {
 
   private onMouseWheel(event: WheelEvent) {
     event.preventDefault();
-    let sign = (event.wheelDelta < 0) ? -1 : 1;
-    let scaleMultiplier = 1. + sign * 0.05;
+    let sign = event.wheelDelta < 0 ? -1 : 1;
+    let scaleMultiplier = 1 + sign * 0.05;
 
     // Zoom around event.offsetX.
-    let dx = (event.offsetX - this.domElement.clientWidth / 2) / this.camera.zoom
-    let dy = (event.offsetY - this.domElement.clientHeight / 2) / this.camera.zoom
-    this.camera.position.x += (scaleMultiplier - 1) * dx
-    this.camera.position.y -= (scaleMultiplier - 1) * dy
+    let dx =
+      (event.offsetX - this.domElement.clientWidth / 2) / this.camera.zoom;
+    let dy =
+      (event.offsetY - this.domElement.clientHeight / 2) / this.camera.zoom;
+    this.camera.position.x += (scaleMultiplier - 1) * dx;
+    this.camera.position.y -= (scaleMultiplier - 1) * dy;
     this.camera.zoom *= scaleMultiplier;
     this.viewHasChanged = true;
   }

--- a/xray/client/main.ts
+++ b/xray/client/main.ts
@@ -14,10 +14,10 @@
 
 'use strict';
 
-import * as THREE from "three";
+import * as THREE from 'three';
 
-import { Maps2DController } from './control';
-import { XRayViewer } from './xray_viewer';
+import {Maps2DController} from './control';
+import {XRayViewer} from './xray_viewer';
 
 function now(): number {
   return +new Date();
@@ -40,10 +40,13 @@ class App {
     renderArea.appendChild(this.renderer.domElement);
 
     this.camera = new THREE.OrthographicCamera(
-      renderArea.clientWidth / - 2,
+      renderArea.clientWidth / -2,
       renderArea.clientWidth / 2,
       renderArea.clientHeight / 2,
-      renderArea.clientHeight / - 2, -100., 100.);
+      renderArea.clientHeight / -2,
+      -100,
+      100
+    );
 
     this.lastFrustumUpdateTime = 0;
     this.viewHasChanged = true;
@@ -51,20 +54,24 @@ class App {
     this.camera.updateMatrixWorld(false);
     this.scene = new THREE.Scene();
 
-    const request = new Request(`/meta`,
-      {
-        method: 'GET',
-        credentials: 'same-origin',
-      });
-
-    window.fetch(request).then(data => data.json()).then((meta: any) => {
-      this.viewer = new XRayViewer(this.scene, meta);
+    const request = new Request(`/meta`, {
+      method: 'GET',
+      credentials: 'same-origin',
     });
+
+    window
+      .fetch(request)
+      .then((data) => data.json())
+      .then((meta: any) => {
+        this.viewer = new XRayViewer(this.scene, meta);
+      });
 
     this.scene.add(this.camera);
 
-    this.controller =
-      new Maps2DController(this.camera, this.renderer.domElement);
+    this.controller = new Maps2DController(
+      this.camera,
+      this.renderer.domElement
+    );
 
     this.lastFrustumUpdateTime = 0;
     window.addEventListener('resize', () => this.onWindowResize(), false);
@@ -72,10 +79,10 @@ class App {
   }
 
   private onWindowResize() {
-    this.camera.left = -window.innerWidth / 2.;
-    this.camera.right = window.innerWidth / 2.;
-    this.camera.top = window.innerHeight / 2.;
-    this.camera.bottom = -window.innerHeight / 2.;
+    this.camera.left = -window.innerWidth / 2;
+    this.camera.right = window.innerWidth / 2;
+    this.camera.top = window.innerHeight / 2;
+    this.camera.bottom = -window.innerHeight / 2;
     this.camera.updateProjectionMatrix();
     this.renderer.setSize(window.innerWidth, window.innerHeight);
   }
@@ -85,12 +92,18 @@ class App {
 
     this.viewHasChanged = this.controller.update() || this.viewHasChanged;
     const time = now();
-    if (time - this.lastFrustumUpdateTime > 250 && this.viewHasChanged && this.viewer !== undefined) {
+    if (
+      time - this.lastFrustumUpdateTime > 250 &&
+      this.viewHasChanged &&
+      this.viewer !== undefined
+    ) {
       this.viewHasChanged = false;
       this.lastFrustumUpdateTime = time;
 
       const matrix = new THREE.Matrix4().multiplyMatrices(
-        this.camera.projectionMatrix, this.camera.matrixWorldInverse);
+        this.camera.projectionMatrix,
+        this.camera.matrixWorldInverse
+      );
       // The camera's zoom is exactly the number of pixels per meter.
       this.viewer.frustumChanged(matrix, this.camera.zoom);
     }

--- a/xray/client/package-lock.json
+++ b/xray/client/package-lock.json
@@ -358,6 +358,12 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
+      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg==",
+      "dev": true
+    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",

--- a/xray/client/package.json
+++ b/xray/client/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "build": "rollup -c",
-    "test": "echo \"Error: no test specified\" && exit 1",
     "format": "prettier --write **/*.ts **/*.js"
   },
   "author": "Holger Rapp <hrapp@lyft.com>",

--- a/xray/client/package.json
+++ b/xray/client/package.json
@@ -5,16 +5,25 @@
   "main": "index.js",
   "scripts": {
     "build": "rollup -c",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "format": "prettier --write **/*.ts **/*.js"
   },
   "author": "Holger Rapp <hrapp@lyft.com>",
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/three": "0.89.0",
+    "prettier": "^1.10.2",
     "rollup": "^0.55.3",
     "rollup-plugin-commonjs": "^8.3.0",
     "rollup-plugin-node-resolve": "^3.0.2",
     "rollup-plugin-typescript": "^0.8.1",
     "three": "0.89.0"
+  },
+  "prettier": {
+    "arrow-parens": "always",
+    "bracket-spacing": false,
+    "print-width": 80,
+    "single-quote": true,
+    "trailing-comma": "es5"
   }
 }

--- a/xray/client/xray_viewer.ts
+++ b/xray/client/xray_viewer.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as THREE from "three";
+import * as THREE from 'three';
 
 function matrixToString(m: THREE.Matrix4): string {
   const me = m.elements;
@@ -33,17 +33,34 @@ class NodeData {
   }
 
   public setTexture(texture: THREE.Texture) {
-    let geometry = new THREE.PlaneGeometry(this.boundingRect['edge_length'], this.boundingRect['edge_length'], 1);
-    geometry.applyMatrix(new THREE.Matrix4().makeTranslation(this.boundingRect['edge_length'] / 2., - this.boundingRect['edge_length'] / 2., 0.));
-    let material = new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide });
+    let geometry = new THREE.PlaneGeometry(
+      this.boundingRect['edge_length'],
+      this.boundingRect['edge_length'],
+      1
+    );
+    geometry.applyMatrix(
+      new THREE.Matrix4().makeTranslation(
+        this.boundingRect['edge_length'] / 2,
+        -this.boundingRect['edge_length'] / 2,
+        0
+      )
+    );
+    let material = new THREE.MeshBasicMaterial({
+      map: texture,
+      side: THREE.DoubleSide,
+    });
     this.plane = new THREE.Mesh(geometry, material);
     this.plane.scale.y = -1;
-    this.plane.position.set(this.boundingRect['min_x'], this.boundingRect['min_y'], 0.);
+    this.plane.position.set(
+      this.boundingRect['min_x'],
+      this.boundingRect['min_y'],
+      0
+    );
   }
-};
+}
 
 export class XRayViewer {
-  private nodes: { [key: string]: NodeData } = {};
+  private nodes: {[key: string]: NodeData} = {};
   private currentlyLoading: number;
   private nodesToLoad: string[] = [];
 
@@ -53,10 +70,14 @@ export class XRayViewer {
 
   public frustumChanged(matrix: THREE.Matrix4, pixelsPerMeter: number) {
     // Figure out which view level represents our current zoom.
-    let full_size_considering_zoom = pixelsPerMeter * this.meta['bounding_rect']['edge_length'];
+    let full_size_considering_zoom =
+      pixelsPerMeter * this.meta['bounding_rect']['edge_length'];
     let level = 0;
     let edge_length_px_for_level = this.meta['tile_size'];
-    while (edge_length_px_for_level < full_size_considering_zoom && level < this.meta['deepest_level']) {
+    while (
+      edge_length_px_for_level < full_size_considering_zoom &&
+      level < this.meta['deepest_level']
+    ) {
       edge_length_px_for_level *= 2;
       level += 1;
     }
@@ -67,11 +88,15 @@ export class XRayViewer {
       {
         method: 'GET',
         credentials: 'same-origin',
-      });
+      }
+    );
 
-    window.fetch(request).then(data => data.json()).then((nodes: any) => {
-      this.nodesUpdate(nodes);
-    });
+    window
+      .fetch(request)
+      .then((data) => data.json())
+      .then((nodes: any) => {
+        this.nodesUpdate(nodes);
+      });
   }
 
   private nodesUpdate(nodes: any) {
@@ -113,7 +138,7 @@ export class XRayViewer {
       return;
     }
     console.log('Swapping in: ', nodeId);
-    // Swap out parents and children. 
+    // Swap out parents and children.
     // TODO(sirver): We never drop any nodes, so memory is used unbounded.
     // TODO(sirver): Parent should only be swapped out if all children are loaded.
     if (nodeId !== 'r') {
@@ -135,4 +160,4 @@ export class XRayViewer {
     this.scene.add(this.nodes[nodeId].plane);
     this.nodes[nodeId].inScene = true;
   }
-};
+}


### PR DESCRIPTION
- Add `npm run format` script to auto-format all JS and TS code under client/
- Update existing code to use Prettier output.