### PR TITLE
Upgrade THREE.js

### DIFF
--- a/xray/client/package.json
+++ b/xray/client/package.json
@@ -17,8 +17,8 @@
     "typescript": "^2.7.0"
   },
   "dependencies": {
-    "@types/three": "0.89.6",
-    "three": "0.89.0"
+    "@types/three": "0.91.8",
+    "three": "0.91"
   },
   "prettier": {
     "arrow-parens": "always",


### PR DESCRIPTION
Upgrade THREE to v0.91. A newer version was actually released yesterday (0.92), but it will take a while for @types/three to be updated and there's nothing in 0.92 that we particularly need.