### PR TITLE
Give every GL object ownership of the shared GL context.

### DIFF
--- a/sdl_viewer/src/box_drawer.rs
+++ b/sdl_viewer/src/box_drawer.rs
@@ -21,27 +21,28 @@ use point_viewer::math::Cube;
 use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
+use std::rc::Rc;
 
 const FRAGMENT_SHADER_OUTLINED_BOX: &str = include_str!("../shaders/box_drawer_outline.fs");
 const VERTEX_SHADER_OUTLINED_BOX: &str = include_str!("../shaders/box_drawer_outline.vs");
 
-pub struct BoxDrawer<'a> {
-    outline_program: GlProgram<'a>,
+pub struct BoxDrawer {
+    outline_program: GlProgram,
 
     // Uniforms locations.
     u_transform: GLint,
     u_color: GLint,
 
     // Vertex array and buffers
-    vertex_array: GlVertexArray<'a>,
-    _buffer_position: GlBuffer<'a>,
-    _buffer_indices: GlBuffer<'a>,
+    vertex_array: GlVertexArray,
+    _buffer_position: GlBuffer,
+    _buffer_indices: GlBuffer,
 }
 
-impl<'a> BoxDrawer<'a> {
-    pub fn new(gl: &'a opengl::Gl) -> Self {
+impl BoxDrawer {
+    pub fn new(gl: Rc<opengl::Gl>) -> Self {
         let outline_program =
-            GlProgram::new(gl, VERTEX_SHADER_OUTLINED_BOX, FRAGMENT_SHADER_OUTLINED_BOX);
+            GlProgram::new(Rc::clone(&gl), VERTEX_SHADER_OUTLINED_BOX, FRAGMENT_SHADER_OUTLINED_BOX);
         let u_transform;
         let u_color;
 
@@ -51,11 +52,11 @@ impl<'a> BoxDrawer<'a> {
             u_color = gl.GetUniformLocation(outline_program.id, c_str!("color"));
         }
 
-        let vertex_array = GlVertexArray::new(gl);
+        let vertex_array = GlVertexArray::new(Rc::clone(&gl));
         vertex_array.bind();
 
         // vertex buffer: define 8 vertices of the box
-        let _buffer_position = GlBuffer::new_array_buffer(gl);
+        let _buffer_position = GlBuffer::new_array_buffer(Rc::clone(&gl));
         _buffer_position.bind();
         let vertices: [[f32; 3]; 8] = [
             [-1.0, -1.0, 1.0],  // vertices of front quad
@@ -77,7 +78,7 @@ impl<'a> BoxDrawer<'a> {
         }
 
         // define index buffer for 24 edges of the box
-        let _buffer_indices = GlBuffer::new_element_array_buffer(gl);
+        let _buffer_indices = GlBuffer::new_element_array_buffer(Rc::clone(&gl));
         _buffer_indices.bind();
         let line_indices: [[i32; 2]; 12] = [
             [0, 1],

--- a/sdl_viewer/src/graphic.rs
+++ b/sdl_viewer/src/graphic.rs
@@ -18,17 +18,18 @@ use glhelper::{compile_shader, link_program};
 use opengl::{self, Gl};
 use opengl::types::GLuint;
 use std::str;
+use std::rc::Rc;
 
-pub struct GlProgram<'a> {
-    pub gl: &'a Gl,
+pub struct GlProgram {
+    pub gl: Rc<Gl>,
     pub id: GLuint,
 }
 
-impl<'a> GlProgram<'a> {
-    pub fn new(gl: &'a opengl::Gl, vertex_shader: &str, fragment_shader: &str) -> Self {
-        let vertex_shader_id = compile_shader(gl, vertex_shader, opengl::VERTEX_SHADER);
-        let fragment_shader_id = compile_shader(gl, fragment_shader, opengl::FRAGMENT_SHADER);
-        let id = link_program(gl, vertex_shader_id, fragment_shader_id);
+impl GlProgram {
+    pub fn new(gl: Rc<opengl::Gl>, vertex_shader: &str, fragment_shader: &str) -> Self {
+        let vertex_shader_id = compile_shader(&*gl, vertex_shader, opengl::VERTEX_SHADER);
+        let fragment_shader_id = compile_shader(&*gl, fragment_shader, opengl::FRAGMENT_SHADER);
+        let id = link_program(&*gl, vertex_shader_id, fragment_shader_id);
 
         // TODO(hrapp): Pull out some saner abstractions around program compilation.
         unsafe {
@@ -39,7 +40,7 @@ impl<'a> GlProgram<'a> {
     }
 }
 
-impl<'a> Drop for GlProgram<'a> {
+impl Drop for GlProgram {
     fn drop(&mut self) {
         unsafe {
             self.gl.DeleteProgram(self.id);
@@ -47,14 +48,14 @@ impl<'a> Drop for GlProgram<'a> {
     }
 }
 
-pub struct GlBuffer<'a> {
-    gl: &'a Gl,
+pub struct GlBuffer {
+    gl: Rc<Gl>,
     id: GLuint,
     buffer_type: GLuint,
 }
 
-impl<'a> GlBuffer<'a> {
-    pub fn new_array_buffer(gl: &'a opengl::Gl) -> Self {
+impl GlBuffer {
+    pub fn new_array_buffer(gl: Rc<opengl::Gl>) -> Self {
         let mut id = 0;
         unsafe {
             gl.GenBuffers(1, &mut id);
@@ -66,7 +67,7 @@ impl<'a> GlBuffer<'a> {
         }
     }
 
-    pub fn new_element_array_buffer(gl: &'a opengl::Gl) -> Self {
+    pub fn new_element_array_buffer(gl: Rc<opengl::Gl>) -> Self {
         let mut id = 0;
         unsafe {
             gl.GenBuffers(1, &mut id);
@@ -85,7 +86,7 @@ impl<'a> GlBuffer<'a> {
     }
 }
 
-impl<'a> Drop for GlBuffer<'a> {
+impl Drop for GlBuffer {
     fn drop(&mut self) {
         unsafe {
             self.gl.DeleteBuffers(1, &self.id);
@@ -93,13 +94,13 @@ impl<'a> Drop for GlBuffer<'a> {
     }
 }
 
-pub struct GlVertexArray<'a> {
-    gl: &'a Gl,
+pub struct GlVertexArray {
+    gl: Rc<Gl>,
     id: GLuint,
 }
 
-impl<'a> GlVertexArray<'a> {
-    pub fn new(gl: &'a Gl) -> Self {
+impl GlVertexArray {
+    pub fn new(gl: Rc<Gl>) -> Self {
         let mut id = 0;
         unsafe {
             gl.GenVertexArrays(1, &mut id);
@@ -114,7 +115,7 @@ impl<'a> GlVertexArray<'a> {
     }
 }
 
-impl<'a> Drop for GlVertexArray<'a> {
+impl Drop for GlVertexArray {
     fn drop(&mut self) {
         unsafe {
             self.gl.DeleteVertexArrays(1, &self.id);

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -52,6 +52,7 @@ use sdl2::video::GLProfile;
 use std::cmp;
 use std::error::Error;
 use std::sync::Arc;
+use std::rc::Rc;
 
 type OctreeFactory = fn(&String) -> Result<Box<Octree>, Box<Error>>;
 
@@ -153,16 +154,16 @@ impl SdlViewer {
 
         assert_eq!(gl_attr.context_profile(), GLProfile::Core);
 
-        let gl = opengl::Gl::load_with(|s| {
+        let gl = Rc::new(opengl::Gl::load_with(|s| {
             let ptr = video_subsystem.gl_get_proc_address(s);
             unsafe { std::mem::transmute(ptr) }
-        });
+        }));
 
-        let node_drawer = NodeDrawer::new(&gl);
+        let node_drawer = NodeDrawer::new(Rc::clone(&gl));
         let mut node_views = NodeViewContainer::new(Arc::clone(&octree), max_nodes_in_memory);
         let mut visible_nodes = Vec::new();
 
-        let box_drawer = BoxDrawer::new(&gl);
+        let box_drawer = BoxDrawer::new(Rc::clone(&gl));
         let octree_box_color = YELLOW;
         let mut show_octree_nodes = false;
 


### PR DESCRIPTION
Before, the `opengl::GL` class was created on the outside and references to it where passed throughout the program. This makes for awkward life-time annotations, so I decided to instead give shared ownership to OpenGL to everything that needs it.

This is done using a std::rc::Rc, a reference counter, that cannot be passed between threads and has the same performance characteristics to a reference at runtime, it is only minimally more expensive on creation (cloning) and deletion.