### PR TITLE
Add new camera controls and minor updates to the native client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,6 +909,7 @@ version = "0.1.0"
 dependencies = [
  "cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "collision 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -32,20 +32,28 @@ This is a native client using [SDL2](https://libsdl.org).
 3. Build with `cargo build --release`. 
 4. Run with `../target/release/sdl_viewer <octree directory>`.
 
-In the point cloud viewer, navigate with the keyboard and rotate with left-click + mouse drag or touchpad. The following keys are bound:
+In the point cloud viewer, navigate with the keyboard or with the mouse or touchpad. Dragging while pressing the left mouse button rotates, dragging while pressing the right mouse button pans the view. The following keys are bound:
 
-| Key           | Action               |
-| ------------- | -------------------- |
-| W             | Move forward         |
-| A             | Move left            |
-| S             | Move backwards       |
-| D             | Move right           |
-| Q             | Move up              |
-| Z             | Move down            |
-| 0             | Increase points size |
-| 9             | Decrease points size |
-| 8             | Brighten scene       |
-| 7             | Darken scene         |
+| Key           | Action                        |
+| ------------- | ----------------------------- |
+| W             | Move forward                  |
+| A             | Move left                     |
+| S             | Move backwards                |
+| D             | Move right                    |
+| Q             | Move up                       |
+| Z             | Move down                     |
+| Up            | Turn up                       |
+| Left          | Turn left                     |
+| Down          | Turn down                     |
+| Right         | Move right                    |
+| 0             | Increase points size          |
+| 9             | Decrease points size          |
+| 8             | Brighten scene                |
+| 7             | Darken scene                  |
+| 7             | Darken scene                  |
+| 2             | Show more points when moving  |
+| 1             | Show fewer points when moving |
+| O             | Show octree nodes             |
 
 ### Web Viewer
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ In the point cloud viewer, navigate with the keyboard or with the mouse or touch
 | 9             | Decrease points size          |
 | 8             | Brighten scene                |
 | 7             | Darken scene                  |
-| 7             | Darken scene                  |
 | 2             | Show more points when moving  |
 | 1             | Show fewer points when moving |
 | O             | Show octree nodes             |

--- a/sdl_viewer/Cargo.toml
+++ b/sdl_viewer/Cargo.toml
@@ -23,6 +23,7 @@ gl_generator = "0.8.0"
 [dependencies]
 cgmath = "0.16.0"
 clap = "^2.31.2"
+collision = "0.18.0"
 lru-cache = "^0.1.1"
 fnv = "1.0.6"
 rand = "0.3.15"

--- a/sdl_viewer/src/box_drawer.rs
+++ b/sdl_viewer/src/box_drawer.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use cgmath::{Matrix, Matrix4};
+use cgmath::{EuclideanSpace, Matrix, Matrix4};
+use collision::{Aabb, Aabb3};
 use graphic::{GlBuffer, GlProgram, GlVertexArray};
 use opengl;
 use opengl::types::{GLboolean, GLint, GLsizeiptr, GLuint};
 use point_viewer::color;
-use point_viewer::math::Cube;
 use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
@@ -166,12 +166,13 @@ impl BoxDrawer {
     // Then we use 'world_to_gl' to transform it into clip space.
     pub fn draw_outlines(
         &self,
-        cube: &Cube,
+        cuboid: &Aabb3<f32>,
         world_to_gl: &Matrix4<f32>,
         color: &color::Color<f32>,
     ) {
-        let scale_matrix = Matrix4::from_scale(cube.edge_length() / 2.0);
-        let translation_matrix = Matrix4::from_translation(cube.center());
+        let dim = cuboid.dim() / 2.0;
+        let scale_matrix = Matrix4::from_nonuniform_scale(dim.x, dim.y, dim.z);
+        let translation_matrix = Matrix4::from_translation(cuboid.center().to_vec());
         let transformation_matrix = world_to_gl * translation_matrix * scale_matrix;
 
         self.draw_outlines_from_transformation(&transformation_matrix, color);

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -304,11 +304,11 @@ impl SdlViewer {
         let octree_argument = matches.value_of("octree").unwrap();
 
         // Maximum number of MB for the octree node cache. The default is 2 GB
-        let cache_size_mb = matches
+        let cache_size_mb: usize = matches
             .value_of("cache_size_mb")
             .unwrap_or("2000")
             .parse()
-            .unwrap();
+            .expect("Could not parse 'cache_size_mb' option.");
 
         // Maximum number of MB for the octree node cache in range 1..16 GB. The default is 2 GB
         let limit_cache_size_mb = cmp::max(1000, cmp::min(16_000, cache_size_mb));
@@ -388,6 +388,10 @@ impl SdlViewer {
                         Scancode::D => camera.moving_right = true,
                         Scancode::Z => camera.moving_down = true,
                         Scancode::Q => camera.moving_up = true,
+                        Scancode::Left => camera.turning_left = true,
+                        Scancode::Right => camera.turning_right = true,
+                        Scancode::Down => camera.turning_down = true,
+                        Scancode::Up => camera.turning_up = true,
                         Scancode::O => renderer.toggle_show_octree_nodes(),
                         Scancode::Num1 => renderer.decrement_max_level_moving(),
                         Scancode::Num2 => renderer.increment_max_level_moving(),
@@ -407,6 +411,10 @@ impl SdlViewer {
                         Scancode::D => camera.moving_right = false,
                         Scancode::Z => camera.moving_down = false,
                         Scancode::Q => camera.moving_up = false,
+                        Scancode::Left => camera.turning_left = false,
+                        Scancode::Right => camera.turning_right = false,
+                        Scancode::Down => camera.turning_down = false,
+                        Scancode::Up => camera.turning_up = false,
                         _ => (),
                     },
                     Event::MouseMotion {
@@ -414,9 +422,12 @@ impl SdlViewer {
                         yrel,
                         mousestate,
                         ..
-                    } if mousestate.left() =>
-                    {
-                        camera.mouse_drag(xrel, yrel)
+                    } => {
+                        if mousestate.left() {
+                            camera.mouse_drag_rotate(xrel, yrel)
+                        } else if mousestate.right() {
+                            camera.mouse_drag_pan(xrel, yrel)
+                        }
                     }
                     Event::MouseWheel { y, .. } => {
                         camera.mouse_wheel(y);

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -14,6 +14,7 @@
 
 extern crate cgmath;
 extern crate clap;
+extern crate collision;
 extern crate fnv;
 extern crate lru_cache;
 extern crate point_viewer;
@@ -241,7 +242,7 @@ impl PointCloudRenderer {
 
             if self.show_octree_nodes {
                 self.box_drawer
-                    .draw_outlines(&view.meta.bounding_cube, &self.world_to_gl, &YELLOW);
+                    .draw_outlines(&view.meta.bounding_cube.to_aabb3(), &self.world_to_gl, &YELLOW);
             }
         }
         if self.needs_drawing {


### PR DESCRIPTION
This adds keyboard controls for rotating the view and a mouse control for panning the view. Minor changes:
* Use the axis-aligned bounding box from the collision crate instead of Cube for the box drawer
* Fix bug where the view doesn't update after resizing
* Update README.md