### PR TITLE
Work around a types issue in webvr.

### DIFF
--- a/octree_web_viewer/client/package-lock.json
+++ b/octree_web_viewer/client/package-lock.json
@@ -11,16 +11,16 @@
     },
     "@types/three": {
       "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.0.27.tgz",
+      "resolved": "http://registry.npmjs.org/@types/three/-/three-0.0.27.tgz",
       "integrity": "sha1-CV2GqaS7tKRcKBcFDkK4uKqD1Bc=",
       "requires": {
-        "@types/webvr-api": "0.0.31"
+        "@types/webvr-api": "0.0.35"
       }
     },
     "@types/webvr-api": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/@types/webvr-api/-/webvr-api-0.0.31.tgz",
-      "integrity": "sha1-9gYf6IoDXTSotqDFX4dYkB7IoI4="
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@types/webvr-api/-/webvr-api-0.0.35.tgz",
+      "integrity": "sha512-jdpJqweU5v7hYwUlHKQU6wzjQvUfBfmTz4WBwVd/5PVGYalKm6YbEnM/3T+M+QzRYf2R/ojBGnrWpjHBZFR3Og=="
     },
     "dat-gui": {
       "version": "0.5.0",
@@ -34,13 +34,13 @@
     },
     "three": {
       "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.83.0.tgz",
+      "resolved": "http://registry.npmjs.org/three/-/three-0.83.0.tgz",
       "integrity": "sha1-O3+UeQrz4CHawfRKJhdWnKIDKws="
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
+      "version": "2.7.2",
+      "resolved": "http://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
     }
   }
 }

--- a/octree_web_viewer/client/package.json
+++ b/octree_web_viewer/client/package.json
@@ -15,7 +15,7 @@
     "@types/three": "0.0.27",
     "dat-gui": "0.5.0",
     "three": "0.83.0",
-    "typescript": "^2.7.0 < 3.0.0"
+    "typescript": "=2.7.2"
   },
   "prettier": {
     "arrow-parens": "always",

--- a/octree_web_viewer/client/package.json
+++ b/octree_web_viewer/client/package.json
@@ -15,7 +15,7 @@
     "@types/three": "0.0.27",
     "dat-gui": "0.5.0",
     "three": "0.83.0",
-    "typescript": "^2.2"
+    "typescript": "^2.7.0 < 3.0.0"
   },
   "prettier": {
     "arrow-parens": "always",

--- a/xray/client/package.json
+++ b/xray/client/package.json
@@ -14,7 +14,7 @@
     "rollup": "^0.55.3",
     "rollup-plugin-commonjs": "^8.3.0",
     "rollup-plugin-node-resolve": "^3.0.2",
-    "typescript": "^2.7.0 < 3.0.0"
+    "typescript": "=2.7.2"
   },
   "dependencies": {
     "@types/three": "0.91.8",

--- a/xray/client/package.json
+++ b/xray/client/package.json
@@ -14,7 +14,7 @@
     "rollup": "^0.55.3",
     "rollup-plugin-commonjs": "^8.3.0",
     "rollup-plugin-node-resolve": "^3.0.2",
-    "typescript": "^2.7.0"
+    "typescript": "^2.7.0 < 3.0.0"
   },
   "dependencies": {
     "@types/three": "0.91.8",


### PR DESCRIPTION
This bug is not in Typescript < 3.0, so we force a version between 2.0 and 3.0 to not get hit by this bug in ci. Once it is fixed we can update to > 3.* eventually again.

https://github.com/Microsoft/TypeScript/issues/26038