### PR TITLE
Fix octree server. It was not reacting to requests.

### DIFF
--- a/point_viewer_grpc/src/bin/octree_server.rs
+++ b/point_viewer_grpc/src/bin/octree_server.rs
@@ -42,6 +42,7 @@ fn main() {
     let port = value_t!(matches, "port", u16).unwrap_or(50051);
     let octree_directory = PathBuf::from(matches.value_of("octree_directory").unwrap());
     let mut server = start_grpc_server(octree_directory, "0.0.0.0", port);
+    server.start();
 
     for &(ref host, port) in server.bind_addrs() {
         println!("listening on {}:{}", host, port);


### PR DESCRIPTION
This broke in ac3b0691e91bc63859dc5fc7dff13c06425548bb. The server is created in a function, but the `server.start()` call was deleted accidentally.
