### PR TITLE
Refactors to make external reuse easier and fix out of files error.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ name = "atty"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -41,7 +41,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -52,7 +52,7 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -320,7 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -341,7 +341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -490,7 +490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.42"
+version = "0.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -662,7 +662,7 @@ name = "num_cpus"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -670,7 +670,7 @@ name = "num_cpus"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -694,7 +694,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -748,6 +748,7 @@ dependencies = [
  "collision 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -866,7 +867,7 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -876,7 +877,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -896,7 +897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -978,7 +979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "sdl2-sys 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -989,7 +990,7 @@ name = "sdl2-sys"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1127,7 +1128,7 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1156,7 +1157,7 @@ name = "time"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1457,7 +1458,7 @@ dependencies = [
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
-"checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
+"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6fddaa003a65722a7fb9e26b0ce95921fe4ba590542ced664d8ce2fa26f9f3ac"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,6 +769,7 @@ dependencies = [
  "point_viewer 0.1.0",
  "point_viewer_grpc_proto_rust 0.1.0",
  "protobuf 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped-pool 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ pbr = "1.0.0-alpha.1"
 protobuf = "2.0.0"
 scoped-pool = "^0.1"
 walkdir = "^0.1.5"
+libc = "0.2.43"
 
 [dependencies.point_viewer_proto_rust]
 path = "point_viewer_proto_rust"

--- a/point_viewer_grpc/Cargo.toml
+++ b/point_viewer_grpc/Cargo.toml
@@ -24,6 +24,7 @@ clap = "2.32.0"
 futures = "0.1.17"
 grpcio = "0.4"
 protobuf = "2.0.0"
+scoped-pool = "^0.1"
 
 [dependencies.point_viewer]
 path = ".."

--- a/point_viewer_grpc/src/bin/query_frustum.rs
+++ b/point_viewer_grpc/src/bin/query_frustum.rs
@@ -19,6 +19,7 @@ extern crate grpcio;
 extern crate point_viewer;
 extern crate point_viewer_grpc_proto_rust;
 extern crate protobuf;
+extern crate scoped_pool;
 
 use cgmath::{Deg, EuclideanSpace, Point3, Rad};
 use collision::{Aabb3, Aabb};
@@ -100,5 +101,6 @@ fn main() {
         })
         .wait()
         .unwrap();
-    build_octree("/tmp/octree", 0.001, bounding_box, Points{points});
+    let pool = scoped_pool::Pool::new(10);
+    build_octree(&pool, "/tmp/octree", 0.001, bounding_box, Points{points});
 }

--- a/src/bin/build_octree.rs
+++ b/src/bin/build_octree.rs
@@ -14,6 +14,7 @@
 
 extern crate clap;
 extern crate point_viewer;
+extern crate scoped_pool;
 
 use std::path::PathBuf;
 use point_viewer::generation::build_octree_from_file;
@@ -49,5 +50,6 @@ fn main() {
 
     let filename = PathBuf::from(matches.value_of("input").unwrap());
 
-    build_octree_from_file(output_directory, resolution, filename);
+    let pool = scoped_pool::Pool::new(10);
+    build_octree_from_file(&pool, output_directory, resolution, filename);
 }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -265,6 +265,16 @@ pub fn build_octree_from_file(pool: &Pool, output_directory: impl AsRef<Path>, r
 }
 
 pub fn build_octree(pool: &Pool, output_directory: impl AsRef<Path>, resolution: f64, bounding_box: Aabb3<f32>, input: impl InternalIterator) {
+    // We open a lot of files during our work. Sometimes users see errors with 'cannot open more
+    // files'. We attempt to increase the rlimits for the number of open files per process here,
+    // but we do not fail if we do not manage to do so.
+    unsafe {
+        let mut rl = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+        libc::getrlimit(libc::RLIMIT_NOFILE, &mut rl);
+        rl.rlim_cur = rl.rlim_max;
+        libc::setrlimit(libc::RLIMIT_NOFILE, &rl);
+    }
+
     // TODO(ksavinash9): This function should return a Result.
     let octree_meta = &octree::OctreeMeta {
         bounding_box,

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -250,7 +250,7 @@ fn find_bounding_box(input: &InputFile) -> Aabb3<f32> {
     bounding_box
 }
 
-pub fn build_octree_from_file(output_directory: impl AsRef<Path>, resolution: f64, filename: impl AsRef<Path>) {
+pub fn build_octree_from_file(pool: &Pool, output_directory: impl AsRef<Path>, resolution: f64, filename: impl AsRef<Path>) {
     // TODO(ksavinash9): This function should return a Result.
     let input = {
         match filename.as_ref().extension().and_then(|s| s.to_str()) {
@@ -261,10 +261,10 @@ pub fn build_octree_from_file(output_directory: impl AsRef<Path>, resolution: f6
     };
     let bounding_box = find_bounding_box(&input);
     let (stream, _) = make_stream(&input);
-    build_octree(output_directory, resolution, bounding_box, stream)
+    build_octree(pool, output_directory, resolution, bounding_box, stream)
 }
 
-pub fn build_octree(output_directory: impl AsRef<Path>, resolution: f64, bounding_box: Aabb3<f32>, input: impl InternalIterator) {
+pub fn build_octree(pool: &Pool, output_directory: impl AsRef<Path>, resolution: f64, bounding_box: Aabb3<f32>, input: impl InternalIterator) {
     // TODO(ksavinash9): This function should return a Result.
     let octree_meta = &octree::OctreeMeta {
         bounding_box,
@@ -301,7 +301,6 @@ pub fn build_octree(output_directory: impl AsRef<Path>, resolution: f64, boundin
     };
 
     println!("Creating octree structure.");
-    let pool = Pool::new(10);
 
     let (leaf_nodes_sender, leaf_nodes_receiver) = mpsc::channel();
     pool.scoped(move |scope| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ extern crate collision;
 #[macro_use]
 extern crate error_chain;
 extern crate fnv;
+extern crate libc;
 extern crate num;
 extern crate num_traits;
 extern crate pbr;

--- a/xray/client/package.json
+++ b/xray/client/package.json
@@ -21,10 +21,10 @@
     "three": "0.95.0"
   },
   "prettier": {
-    "arrow-parens": "always",
-    "bracket-spacing": false,
-    "print-width": 80,
-    "single-quote": true,
-    "trailing-comma": "es5"
+    "arrowParens": "always",
+    "bracketSpacing": false,
+    "printWidth": 80,
+    "singleQuote": true,
+    "trailingComma": "es5"
   }
 }

--- a/xray/client/xray_viewer.ts
+++ b/xray/client/xray_viewer.ts
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-import * as THREE from "three";
+import * as THREE from 'three';
 
 function matrixToString(m: THREE.Matrix4): string {
   const me = m.elements;
@@ -20,8 +20,8 @@ function matrixToString(m: THREE.Matrix4): string {
     me[12].toFixed(10),
     me[13].toFixed(10),
     me[14].toFixed(10),
-    me[15].toFixed(10)
-  ].join(",");
+    me[15].toFixed(10),
+  ].join(',');
 }
 
 class NodeData {
@@ -42,32 +42,32 @@ class NodeData {
       return;
     }
     let geometry = new THREE.PlaneGeometry(
-      this.boundingRect["edge_length"],
-      this.boundingRect["edge_length"],
+      this.boundingRect['edge_length'],
+      this.boundingRect['edge_length'],
       1
     );
     geometry.applyMatrix(
       new THREE.Matrix4().makeTranslation(
-        this.boundingRect["edge_length"] / 2,
-        this.boundingRect["edge_length"] / 2,
+        this.boundingRect['edge_length'] / 2,
+        this.boundingRect['edge_length'] / 2,
         0
       )
     );
     let material = new THREE.MeshBasicMaterial({
       map: texture,
-      side: THREE.DoubleSide
+      side: THREE.DoubleSide,
     });
     this.plane = new THREE.Mesh(geometry, material);
     this.plane.position.set(
-      this.boundingRect["min_x"],
-      this.boundingRect["min_y"],
+      this.boundingRect['min_x'],
+      this.boundingRect['min_y'],
       -100
     );
   }
 }
 
 export class XRayViewer {
-  private nodes: { [key: string]: NodeData } = {};
+  private nodes: {[key: string]: NodeData} = {};
   private currentlyLoading: number;
   private nodesToLoad: string[] = [];
   private nextNodesForLevelQueryId: number;
@@ -81,7 +81,7 @@ export class XRayViewer {
     this.displayLevel = 0;
     window
       .fetch(`${this.prefix}/meta`)
-      .then(data => data.json())
+      .then((data) => data.json())
       .then((meta: any) => {
         this.meta = meta;
       });
@@ -91,16 +91,16 @@ export class XRayViewer {
     this.isDisposed = true;
     for (const [nodeId, node] of Object.entries(this.nodes)) {
       if (this.nodes[nodeId].inScene) {
-          this.removeFromScene(this.nodes[nodeId]);
+        this.removeFromScene(this.nodes[nodeId]);
       }
     }
     this.nodesToLoad = [];
   }
 
   private removeFromScene(node: NodeData) {
-      // TODO(sirver): This does not dispose of texture and plane geometry.
-      this.scene.remove(node.plane);
-      node.inScene = false;
+    // TODO(sirver): This does not dispose of texture and plane geometry.
+    this.scene.remove(node.plane);
+    node.inScene = false;
   }
 
   public isInitialized(): boolean {
@@ -113,12 +113,12 @@ export class XRayViewer {
     }
     // Figure out which view level represents our current zoom.
     let full_size_considering_zoom =
-      pixelsPerMeter * this.meta["bounding_rect"]["edge_length"];
+      pixelsPerMeter * this.meta['bounding_rect']['edge_length'];
     let level = 0;
-    let edge_length_px_for_level = this.meta["tile_size"];
+    let edge_length_px_for_level = this.meta['tile_size'];
     while (
       edge_length_px_for_level < full_size_considering_zoom &&
-      level < this.meta["deepest_level"]
+      level < this.meta['deepest_level']
     ) {
       edge_length_px_for_level *= 2;
       level += 1;
@@ -133,7 +133,7 @@ export class XRayViewer {
       .fetch(
         `${this.prefix}/nodes_for_level?level=${level}&matrix=${matrixStr}`
       )
-      .then(data => data.json())
+      .then((data) => data.json())
       .then((nodes: any) => {
         // Ignore responses that arrive after we've already issued a new request.
         // TODO(sirver): Look into axios for canceling running requests.
@@ -146,7 +146,7 @@ export class XRayViewer {
   private nodesUpdate(nodes: any) {
     this.nodesToLoad = [];
     for (let i = 0, len = nodes.length; i < len; i++) {
-      let node = this.getOrCreate(nodes[i]["id"], nodes[i]["bounding_rect"]);
+      let node = this.getOrCreate(nodes[i]['id'], nodes[i]['bounding_rect']);
       if (node.plane !== null) {
         this.swapIn(node.id);
         continue;
@@ -168,13 +168,13 @@ export class XRayViewer {
     let nodeId = this.nodesToLoad.shift();
     new THREE.TextureLoader().load(
       `${this.prefix}/node_image/${nodeId}`,
-      texture => {
+      (texture) => {
         this.currentlyLoading -= 1;
         this.loadNext();
         const level = nodeId.length - 1;
         // Let's show all the beautiful pixels on the lowest zoom level.
         if (level == this.meta['deepest_level']) {
-            texture.magFilter = THREE.NearestFilter;
+          texture.magFilter = THREE.NearestFilter;
         }
         this.nodes[nodeId].setTexture(texture);
         this.swapIn(nodeId);

--- a/xray/src/bin/build_xray_quadtree.rs
+++ b/xray/src/bin/build_xray_quadtree.rs
@@ -10,24 +10,11 @@ extern crate quadtree;
 extern crate scoped_pool;
 extern crate xray;
 
-use cgmath::{Point2, Point3};
-use collision::{Aabb, Aabb3};
-use fnv::FnvHashSet;
 use octree::OnDiskOctree;
 use point_viewer::octree;
-use protobuf::Message;
-use quadtree::{ChildIndex, Node, NodeId, Rect};
 use scoped_pool::Pool;
-use std::error::Error;
-use std::fs;
-use std::fs::File;
-use std::io::BufWriter;
-use std::path::{Path, PathBuf};
-use std::sync::mpsc;
-use xray::{proto,
-           generation::{xray_from_points, ColoringStrategy, ColoringStrategyArgument,
-                        ColoringStrategyKind},
-           CURRENT_VERSION};
+use std::path::Path;
+use xray::generation::{ColoringStrategyArgument, ColoringStrategyKind};
 
 fn parse_arguments() -> clap::ArgMatches<'static> {
     clap::App::new("build_xray_quadtree")
@@ -85,167 +72,6 @@ fn parse_arguments() -> clap::ArgMatches<'static> {
         .get_matches()
 }
 
-fn find_quadtree_bounding_rect_and_levels(bbox: &Aabb3<f32>, tile_size_m: f32) -> (Rect, u8) {
-    let mut levels = 0;
-    let mut cur_size = tile_size_m;
-    while cur_size < bbox.dim().x || cur_size < bbox.dim().y {
-        cur_size *= 2.;
-        levels += 1;
-    }
-    (
-        Rect::new(Point2::new(bbox.min().x, bbox.min().y), cur_size),
-        levels,
-    )
-}
-
-pub fn get_image_path(directory: &Path, id: NodeId) -> PathBuf {
-    let mut rv = directory.join(&id.to_string());
-    rv.set_extension("png");
-    rv
-}
-
-fn run(
-    octree_directory: &Path,
-    output_directory: &Path,
-    resolution: f32,
-    tile_size_px: u32,
-    coloring_strategy_kind: ColoringStrategyKind,
-) -> Result<(), Box<Error>> {
-    let octree = &OnDiskOctree::new(octree_directory)?;
-
-    // Ignore errors, maybe directory is already there.
-    let _ = fs::create_dir(output_directory);
-
-    let bounding_box = octree.bounding_box();
-
-    let (bounding_rect, deepest_level) =
-        find_quadtree_bounding_rect_and_levels(&bounding_box, tile_size_px as f32 * resolution);
-
-    let pool = Pool::new(10);
-
-    // Create the deepest level of the quadtree.
-    let (parents_to_create_tx, mut parents_to_create_rx) = mpsc::channel();
-    let (all_nodes_tx, all_nodes_rx) = mpsc::channel();
-    println!("Building level {}.", deepest_level);
-
-    pool.scoped(|scope| {
-        let mut open = vec![Node::root_with_bounding_rect(bounding_rect.clone())];
-        while !open.is_empty() {
-            let node = open.pop().unwrap();
-            if node.level() == deepest_level {
-                let parents_to_create_tx_clone = parents_to_create_tx.clone();
-                let all_nodes_tx_clone = all_nodes_tx.clone();
-                let strategy: Box<ColoringStrategy> = coloring_strategy_kind.new_strategy();
-                scope.execute(move || {
-                    let bbox = Aabb3::new(
-                        Point3::new(
-                            node.bounding_rect.min().x,
-                            node.bounding_rect.min().y,
-                            bounding_box.min().z,
-                        ),
-                        Point3::new(
-                            node.bounding_rect.max().x,
-                            node.bounding_rect.max().y,
-                            bounding_box.max().z,
-                        ),
-                    );
-                    if xray_from_points(
-                        octree,
-                        &bbox,
-                        &get_image_path(output_directory, node.id),
-                        tile_size_px,
-                        tile_size_px,
-                        strategy,
-                    ) {
-                        all_nodes_tx_clone.send(node.id).unwrap();
-                        node.id
-                            .parent_id()
-                            .map(|id| parents_to_create_tx_clone.send(id).unwrap());
-                    }
-                });
-            } else {
-                for i in 0..4 {
-                    open.push(node.get_child(ChildIndex::from_u8(i)));
-                }
-            }
-        }
-    });
-    drop(parents_to_create_tx);
-
-    for current_level in (0..deepest_level).rev() {
-        println!("Building level {}.", current_level);
-        let nodes_to_create: FnvHashSet<NodeId> = parents_to_create_rx.into_iter().collect();
-        let (parents_to_create_tx, new_rx) = mpsc::channel();
-        parents_to_create_rx = new_rx;
-        pool.scoped(|scope| {
-            for node_id in nodes_to_create {
-                all_nodes_tx.send(node_id).unwrap();
-                let tx_clone = parents_to_create_tx.clone();
-                scope.execute(move || {
-                    let mut children = [ None, None, None, None ];
-
-                    // We a right handed coordinate system with the x-axis of world and images
-                    // aligning. This means that the y-axis aligns too, but the origin of the image
-                    // space must be at the bottom left. Since images have their origin at the top
-                    // left, we need actually have to invert y and go from the bottom of the image.
-                    for id in 0..4 {
-                        let png = get_image_path(
-                            output_directory,
-                            node_id.get_child_id(ChildIndex::from_u8(id)),
-                        );
-                        if !png.exists() {
-                            continue;
-                        }
-                        children[id as usize] = Some(image::open(&png).unwrap().to_rgb());
-                    }
-                    let large_image = xray::generation::build_parent(&children);
-                    let image = image::DynamicImage::ImageRgb8(large_image).resize(
-                        tile_size_px,
-                        tile_size_px,
-                        image::FilterType::Lanczos3,
-                    );
-                    image
-                        .as_rgb8()
-                        .unwrap()
-                        .save(&get_image_path(output_directory, node_id))
-                        .unwrap();
-                    node_id.parent_id().map(|id| tx_clone.send(id).unwrap());
-                });
-            }
-        });
-        drop(parents_to_create_tx);
-    }
-    drop(all_nodes_tx);
-
-    let meta = {
-        let mut meta = proto::Meta::new();
-        meta.mut_bounding_rect()
-            .mut_min()
-            .set_x(bounding_rect.min().x);
-        meta.mut_bounding_rect()
-            .mut_min()
-            .set_y(bounding_rect.min().y);
-        meta.mut_bounding_rect()
-            .set_edge_length(bounding_rect.edge_length());
-        meta.set_deepest_level(deepest_level as u32);
-        meta.set_tile_size(tile_size_px);
-        meta.set_version(CURRENT_VERSION);
-
-        for node_id in all_nodes_rx {
-            let mut proto = proto::NodeId::new();
-            proto.set_index(node_id.index());
-            proto.set_level(node_id.level() as u32);
-            meta.mut_nodes().push(proto);
-        }
-        meta
-    };
-
-    let mut buf_writer = BufWriter::new(File::create(output_directory.join("meta.pb")).unwrap());
-    meta.write_to_writer(&mut buf_writer).unwrap();
-
-    Ok(())
-}
-
 pub fn main() {
     let args = parse_arguments();
     let resolution = args.value_of("resolution")
@@ -280,8 +106,11 @@ pub fn main() {
     let octree_directory = Path::new(args.value_of("octree_directory").unwrap());
     let output_directory = Path::new(args.value_of("output_directory").unwrap());
 
-    run(
-        octree_directory,
+    let pool = Pool::new(10);
+    let octree = OnDiskOctree::new(octree_directory).expect("Could not open octree.");
+    xray::generation::build_xray_quadtree(
+        &pool,
+        &octree,
         output_directory,
         resolution,
         tile_size,

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -1,13 +1,23 @@
 // Code related to X-Ray generation.
 
+use cgmath::{Point2, Point3};
 use collision::{Aabb, Aabb3};
 use fnv::{FnvHashMap, FnvHashSet};
 use image::{self, GenericImage};
-use point_viewer::{octree, InternalIterator, Point, color::{Color, WHITE}};
 use point_viewer::math::clamp;
-use std::collections::hash_map::Entry;
-use std::path::Path;
+use point_viewer::{octree, InternalIterator, Point, color::{Color, WHITE}};
+use protobuf::Message;
+use quadtree::{ChildIndex, Node, NodeId, Rect};
+use scoped_pool::Pool;
 use stats::OnlineStats;
+use std::collections::hash_map::Entry;
+use std::error::Error;
+use std::fs::{self, File};
+use std::io::BufWriter;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use proto;
+use CURRENT_VERSION;
 
 // The number of Z-buckets we subdivide our bounding cube into along the z-direction. This affects
 // the saturation of a point in x-rays: the more buckets contain a point, the darker the pixel
@@ -375,3 +385,161 @@ pub fn xray_from_points(
     image.save(png_file).unwrap();
     true
 }
+
+fn find_quadtree_bounding_rect_and_levels(bbox: &Aabb3<f32>, tile_size_m: f32) -> (Rect, u8) {
+    let mut levels = 0;
+    let mut cur_size = tile_size_m;
+    while cur_size < bbox.dim().x || cur_size < bbox.dim().y {
+        cur_size *= 2.;
+        levels += 1;
+    }
+    (
+        Rect::new(Point2::new(bbox.min().x, bbox.min().y), cur_size),
+        levels,
+    )
+}
+
+pub fn get_image_path(directory: &Path, id: NodeId) -> PathBuf {
+    let mut rv = directory.join(&id.to_string());
+    rv.set_extension("png");
+    rv
+}
+
+pub fn build_xray_quadtree(
+    pool: &Pool,
+    octree: &octree::OnDiskOctree,
+    output_directory: &Path,
+    resolution: f32,
+    tile_size_px: u32,
+    coloring_strategy_kind: ColoringStrategyKind,
+) -> Result<(), Box<Error>> {
+    // Ignore errors, maybe directory is already there.
+    let _ = fs::create_dir(output_directory);
+
+    let bounding_box = octree.bounding_box();
+    let (bounding_rect, deepest_level) =
+        find_quadtree_bounding_rect_and_levels(&bounding_box, tile_size_px as f32 * resolution);
+
+    // Create the deepest level of the quadtree.
+    let (parents_to_create_tx, mut parents_to_create_rx) = mpsc::channel();
+    let (all_nodes_tx, all_nodes_rx) = mpsc::channel();
+    println!("Building level {}.", deepest_level);
+
+    pool.scoped(|scope| {
+        let mut open = vec![Node::root_with_bounding_rect(bounding_rect.clone())];
+        while !open.is_empty() {
+            let node = open.pop().unwrap();
+            if node.level() == deepest_level {
+                let parents_to_create_tx_clone = parents_to_create_tx.clone();
+                let all_nodes_tx_clone = all_nodes_tx.clone();
+                let strategy: Box<ColoringStrategy> = coloring_strategy_kind.new_strategy();
+                scope.execute(move || {
+                    let bbox = Aabb3::new(
+                        Point3::new(
+                            node.bounding_rect.min().x,
+                            node.bounding_rect.min().y,
+                            bounding_box.min().z,
+                        ),
+                        Point3::new(
+                            node.bounding_rect.max().x,
+                            node.bounding_rect.max().y,
+                            bounding_box.max().z,
+                        ),
+                    );
+                    if xray_from_points(
+                        octree,
+                        &bbox,
+                        &get_image_path(output_directory, node.id),
+                        tile_size_px,
+                        tile_size_px,
+                        strategy,
+                    ) {
+                        all_nodes_tx_clone.send(node.id).unwrap();
+                        node.id
+                            .parent_id()
+                            .map(|id| parents_to_create_tx_clone.send(id).unwrap());
+                    }
+                });
+            } else {
+                for i in 0..4 {
+                    open.push(node.get_child(ChildIndex::from_u8(i)));
+                }
+            }
+        }
+    });
+    drop(parents_to_create_tx);
+
+    for current_level in (0..deepest_level).rev() {
+        println!("Building level {}.", current_level);
+        let nodes_to_create: FnvHashSet<NodeId> = parents_to_create_rx.into_iter().collect();
+        let (parents_to_create_tx, new_rx) = mpsc::channel();
+        parents_to_create_rx = new_rx;
+        pool.scoped(|scope| {
+            for node_id in nodes_to_create {
+                all_nodes_tx.send(node_id).unwrap();
+                let tx_clone = parents_to_create_tx.clone();
+                scope.execute(move || {
+                    let mut children = [ None, None, None, None ];
+
+                    // We a right handed coordinate system with the x-axis of world and images
+                    // aligning. This means that the y-axis aligns too, but the origin of the image
+                    // space must be at the bottom left. Since images have their origin at the top
+                    // left, we need actually have to invert y and go from the bottom of the image.
+                    for id in 0..4 {
+                        let png = get_image_path(
+                            output_directory,
+                            node_id.get_child_id(ChildIndex::from_u8(id)),
+                        );
+                        if !png.exists() {
+                            continue;
+                        }
+                        children[id as usize] = Some(image::open(&png).unwrap().to_rgb());
+                    }
+                    let large_image = build_parent(&children);
+                    let image = image::DynamicImage::ImageRgb8(large_image).resize(
+                        tile_size_px,
+                        tile_size_px,
+                        image::FilterType::Lanczos3,
+                    );
+                    image
+                        .as_rgb8()
+                        .unwrap()
+                        .save(&get_image_path(output_directory, node_id))
+                        .unwrap();
+                    node_id.parent_id().map(|id| tx_clone.send(id).unwrap());
+                });
+            }
+        });
+        drop(parents_to_create_tx);
+    }
+    drop(all_nodes_tx);
+
+    let meta = {
+        let mut meta = proto::Meta::new();
+        meta.mut_bounding_rect()
+            .mut_min()
+            .set_x(bounding_rect.min().x);
+        meta.mut_bounding_rect()
+            .mut_min()
+            .set_y(bounding_rect.min().y);
+        meta.mut_bounding_rect()
+            .set_edge_length(bounding_rect.edge_length());
+        meta.set_deepest_level(deepest_level as u32);
+        meta.set_tile_size(tile_size_px);
+        meta.set_version(CURRENT_VERSION);
+
+        for node_id in all_nodes_rx {
+            let mut proto = proto::NodeId::new();
+            proto.set_index(node_id.index());
+            proto.set_level(node_id.level() as u32);
+            meta.mut_nodes().push(proto);
+        }
+        meta
+    };
+
+    let mut buf_writer = BufWriter::new(File::create(output_directory.join("meta.pb")).unwrap());
+    meta.write_to_writer(&mut buf_writer).unwrap();
+
+    Ok(())
+}
+

--- a/xray/src/lib.rs
+++ b/xray/src/lib.rs
@@ -10,6 +10,7 @@ extern crate point_viewer;
 extern crate protobuf;
 extern crate quadtree;
 extern crate router;
+extern crate scoped_pool;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
- Refactor to reuse xray generation code & octree generation as a library with providing our own scoped pool instance. 
- Reformat frontend code to reduce diff to internal version.
- Attempt to fix #121.