### PR TITLE
Abstract out a trait for the XRay Quadtree.

### DIFF
--- a/xray/src/bin/web_viewer.rs
+++ b/xray/src/bin/web_viewer.rs
@@ -67,7 +67,7 @@ fn main() {
     router.get("/", index);
     router.get("/app_bundle.js", app_bundle);
     router.get("/app_bundle.js.map", app_bundle_source_map);
-    xray::backend::serve("", &mut router, xray::backend::OnDiskXRayProvider::new(quadtree_directory).expect("Could not serve from directory. Not a xray directory?")).unwrap();
+    xray::backend::serve("", &mut router, xray::backend::OnDiskXRay::new(quadtree_directory).expect("Could not serve from directory. Not a xray directory?")).unwrap();
 
     println!("Listening on port {}.", port);
     Iron::new(router).http(("0.0.0.0", port)).unwrap();

--- a/xray/src/bin/web_viewer.rs
+++ b/xray/src/bin/web_viewer.rs
@@ -67,7 +67,7 @@ fn main() {
     router.get("/", index);
     router.get("/app_bundle.js", app_bundle);
     router.get("/app_bundle.js.map", app_bundle_source_map);
-    xray::backend::serve("", &mut router, quadtree_directory);
+    xray::backend::serve("", &mut router, xray::backend::OnDiskXRayProvider::new(quadtree_directory).expect("Could not serve from directory. Not a xray directory?")).unwrap();
 
     println!("Listening on port {}.", port);
     Iron::new(router).http(("0.0.0.0", port)).unwrap();

--- a/xray/src/lib.rs
+++ b/xray/src/lib.rs
@@ -22,13 +22,12 @@ extern crate stats;
 use cgmath::Point2;
 use fnv::FnvHashSet;
 use quadtree::{NodeId, Rect};
-use std::fs::File;
-use std::io::{Cursor, Read};
+use std::io::{self, Cursor};
 use std::path::Path;
 
 pub const CURRENT_VERSION: i32 = 2;
 
-#[derive(Debug)]
+#[derive(Debug,Clone)]
 pub struct Meta {
     pub nodes: FnvHashSet<NodeId>,
     pub bounding_rect: Rect,
@@ -36,40 +35,40 @@ pub struct Meta {
     pub deepest_level: u8,
 }
 
+// TODO(sirver): This should all return errors.
 impl Meta {
-    // Reads the meta file from disk. Panics on error
-    pub fn from_disk<P: AsRef<Path>>(filename: P) -> Self {
-        let meta = {
-            let mut data = Vec::new();
-            File::open(filename)
-                .expect("Could not proto file.")
-                .read_to_end(&mut data)
-                .unwrap();
+    pub fn from_disk<P: AsRef<Path>>(filename: P) -> io::Result<Self> {
+        let proto = {
+            let data = std::fs::read(filename)?;
             protobuf::parse_from_reader::<proto::Meta>(&mut Cursor::new(data))
-                .expect("Could not parse meta.pb")
+                .map_err(|_| io::Error::new(io::ErrorKind::Other, "Could not parse meta.pb"))?
         };
+        Ok(Self::from_proto(&proto))
+    }
 
-        if meta.version != CURRENT_VERSION {
+    // Reads the meta from the provided encoded protobuf.
+    pub fn from_proto(proto: &proto::Meta) -> Self {
+        if proto.version != CURRENT_VERSION {
             panic!(
                 "Invalid version. We only support {}, but found {}.",
-                CURRENT_VERSION, meta.version
+                CURRENT_VERSION, proto.version
             );
         }
 
         Meta {
-            nodes: meta.nodes
+            nodes: proto.nodes
                 .iter()
                 .map(|n| NodeId::new(n.level as u8, n.index))
                 .collect(),
             bounding_rect: Rect::new(
                 Point2::new(
-                    meta.get_bounding_rect().get_min().x,
-                    meta.get_bounding_rect().get_min().y,
+                    proto.get_bounding_rect().get_min().x,
+                    proto.get_bounding_rect().get_min().y,
                 ),
-                meta.get_bounding_rect().get_edge_length(),
+                proto.get_bounding_rect().get_edge_length(),
             ),
-            tile_size: meta.tile_size,
-            deepest_level: meta.deepest_level as u8,
+            tile_size: proto.tile_size,
+            deepest_level: proto.deepest_level as u8,
         }
     }
 }


### PR DESCRIPTION
This will make it possible to swap in different IO backends for serving, in our case reading from AWS s3 Backends.