### PR TITLE
Add all_points rpc query and benchmark for streaming points

### DIFF
--- a/point_viewer_grpc/src/bin/octree_benchmark.rs
+++ b/point_viewer_grpc/src/bin/octree_benchmark.rs
@@ -1,0 +1,112 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[macro_use]
+extern crate clap;
+extern crate futures;
+extern crate grpcio;
+extern crate point_viewer;
+extern crate point_viewer_grpc;
+extern crate point_viewer_grpc_proto_rust;
+
+use point_viewer_grpc_proto_rust::proto;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use futures::future::Future;
+use futures::Stream;
+use grpcio::{ChannelBuilder, Environment};
+use point_viewer::octree::OnDiskOctree;
+use point_viewer::{InternalIterator, Point};
+use point_viewer_grpc::proto_grpc::OctreeClient;
+use point_viewer_grpc::service::start_grpc_server;
+
+fn main() {
+    let matches = clap::App::new("octree_benchmark")
+        .args(&[
+            clap::Arg::with_name("port")
+                .help("Port for the server to listen on for connections. [50051]")
+                .long("port")
+                .takes_value(true),
+            clap::Arg::with_name("no-client")
+                .help("Do not actually send points, only read them on the server.")
+                .long("no-client")
+                .takes_value(false),
+            clap::Arg::with_name("num-points")
+                .help("Number of points to stream. [50000000]")
+                .long("num-points")
+                .takes_value(true),
+            clap::Arg::with_name("octree_directory")
+                .help("Input directory of the octree directory to serve.")
+                .index(1)
+                .required(true),
+        ])
+        .get_matches();
+
+    let octree_directory = PathBuf::from(
+        matches
+            .value_of("octree_directory")
+            .expect("octree_directory not given"),
+    );
+    let num_points = u64::from_str(matches.value_of("num-points").unwrap_or("50000000"))
+        .expect("Could not num-points");
+    if matches.is_present("no-client") {
+        server_benchmark(octree_directory, num_points)
+    } else {
+        let port = value_t!(matches, "port", u16).unwrap_or(50051);
+        full_benchmark(octree_directory, num_points, port)
+    }
+}
+
+fn server_benchmark(octree_directory: PathBuf, num_points: u64) {
+    let octree = OnDiskOctree::new(&octree_directory).unwrap();
+    let mut counter: u64 = 0;
+    octree.all_points().for_each(|_p: &Point| {
+        if counter % 1000000 == 0 {
+            println!("Streamed {}M points", counter / 1000000);
+        }
+        counter += 1;
+        if counter == num_points {
+            std::process::exit(0)
+        }
+    });
+}
+
+fn full_benchmark(octree_directory: PathBuf, num_points: u64, port: u16) {
+    let mut server = start_grpc_server(octree_directory, "0.0.0.0", port);
+    server.start();
+
+    let env = Arc::new(Environment::new(1));
+    let ch = ChannelBuilder::new(env).connect(&format!("localhost:{}", port));
+    let client = OctreeClient::new(ch);
+
+    let req = proto::GetAllPointsRequest::new();
+    let receiver = client.get_all_points(&req).unwrap();
+
+    let mut counter: u64 = 0;
+
+    for rep in receiver.wait() {
+        for _pos in rep.expect("Stream error").get_positions().iter() {
+            if counter % 1000000 == 0 {
+                println!("Streamed {}M points", counter / 1000000);
+            }
+            counter += 1;
+            if counter == num_points {
+                std::process::exit(0)
+            }
+        }
+    }
+
+    let _ = server.shutdown().wait();
+}

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -42,6 +42,7 @@ struct OctreeService {
 enum OctreeQuery {
     FrustumQuery(Matrix4<f32>),
     BoxQuery(Aabb3<f32>),
+    FullPointcloudQuery,
 }
 
 fn stream_points_back_to_sink(
@@ -131,6 +132,7 @@ fn stream_points_back_to_sink(
             match query {
                 OctreeQuery::BoxQuery(bounding_box) => octree.points_in_box(&bounding_box).for_each(func),
                 OctreeQuery::FrustumQuery(frustum_matrix) => octree.points_in_frustum(&frustum_matrix).for_each(func),
+                OctreeQuery::FullPointcloudQuery => octree.all_points().for_each(func),
             };
         }
         tx.send((reply, WriteFlags::default())).unwrap();
@@ -226,6 +228,16 @@ impl proto_grpc::Octree for OctreeService {
         };
         stream_points_back_to_sink(OctreeQuery::BoxQuery(bounding_box), self.octree.clone(), ctx, resp)
     }
+
+    fn get_all_points(
+        &self,
+        ctx: RpcContext,
+        _req: proto::GetAllPointsRequest,
+        resp: ServerStreamingSink<proto::PointsReply>,
+    ) {
+        stream_points_back_to_sink(OctreeQuery::FullPointcloudQuery, self.octree.clone(), ctx, resp)
+    }
+
 }
 
 pub fn start_grpc_server(

--- a/point_viewer_grpc_proto_rust/src/proto.proto
+++ b/point_viewer_grpc_proto_rust/src/proto.proto
@@ -27,6 +27,8 @@ service Octree {
       returns (stream PointsReply);
   rpc GetPointsInFrustum(GetPointsInFrustumRequest)
       returns (stream PointsReply);
+  rpc GetAllPoints(GetAllPointsRequest)
+      returns (stream PointsReply);
 }
 
 message GetMetaRequest {
@@ -68,6 +70,9 @@ message GetPointsInFrustumRequest {
 
   // Distance from the viewer to the far clipping plane.
   double z_far = 6;
+}
+
+message GetAllPointsRequest {
 }
 
 message PointsReply {


### PR DESCRIPTION
Useful for performance optimization. The GetAllPoints query is helpful because it's a common use case and just using a huge bounding box is hacky. Furthermore, in the benchmark we don't know which pointcloud, and thus bounding box, will be used.