### PR TITLE
Make Semantic Map Viewer request handlers public

### DIFF
--- a/xray/src/backend.rs
+++ b/xray/src/backend.rs
@@ -67,8 +67,8 @@ impl XRay for OnDiskXRay {
     }
 }
 
-struct HandleNodeImage<T: XRay> {
-    xray_provider: T, 
+pub struct HandleNodeImage<T: XRay> {
+    pub xray_provider: T, 
 }
 
 impl<T: XRay + Send + 'static> iron::Handler for HandleNodeImage<T> {
@@ -84,8 +84,8 @@ impl<T: XRay + Send + 'static> iron::Handler for HandleNodeImage<T> {
     }
 }
 
-struct HandleMeta {
-    meta: Arc<Meta>,
+pub struct HandleMeta {
+    pub meta: Arc<Meta>,
 }
 
 impl iron::Handler for HandleMeta {
@@ -105,8 +105,8 @@ impl iron::Handler for HandleMeta {
     }
 }
 
-struct HandleNodesForLevel {
-    meta: Arc<Meta>,
+pub struct HandleNodesForLevel {
+    pub meta: Arc<Meta>,
 }
 
 impl iron::Handler for HandleNodesForLevel {


### PR DESCRIPTION
## Description:

To allow for a more individualized handling of serving x-rays make the `iron` handlers public.