### PR TITLE
Changed the GRPC client interface to a callback based one to support streaming

### DIFF
--- a/sdl_viewer/src/bin/sdl_viewer.rs
+++ b/sdl_viewer/src/bin/sdl_viewer.rs
@@ -20,7 +20,10 @@ use sdl_viewer::SdlViewer;
 fn main() {
     SdlViewer::new()
         .register_octree_factory("grpc:".into(), |p| {
-            Ok(Box::new(point_viewer_grpc::GrpcOctree::new(p.as_str())))
+            Ok(Box::new(
+                point_viewer_grpc::GrpcOctree::new(p.as_str())
+                    .expect("Could not connect to GRPC server"),
+            ))
         })
         .run();
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,5 +37,9 @@ error_chain! {
         NodeNotFound {
             description("The node does not exist.")
         }
+
+        Grpc {
+            description("Grpc request failed")
+        }
     }
 }


### PR DESCRIPTION
A more ergonomic interface would require async, which is more work that I am willing to put in currently.

Before, all points returned from gRPC where streamed into a Vec, which then was passed on to the consumers. Now the consumers need to provide a callback function that takes a bunch of Points (~100000 per round) and the function can return a bool to indicate if it wants to continue (true) or stop (false) being called with new points.