### PR TITLE
Adjust name of web viewer binary in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To build,
 5. Build the client: `npm run build`.
 
 Then build the server: `cargo build --release`.
-Serve up the octree using `../target/release/octree_web_viewer <octree directory>`, open Chrome to <http://localhost:5433>, navigate with WASD and left-click-drag on the mouse.
+Serve up the octree using `../target/release/points_web_viewer <octree directory>`, open Chrome to <http://localhost:5433>, navigate with WASD and left-click-drag on the mouse.
 The mouse wheel adjusts movement speed.
 
 The client files (HTML and JavaScript) are embedded in the `octree_web_viewer` binary, so it is fully stand alone.


### PR DESCRIPTION
I was just running through the steps outlined in README. The binary created for the web viewer has a wrong name, which is corrected with this PR.