### PR TITLE
Have the elapsed time affecting the amount of movement and rotation.

### DIFF
--- a/sdl_viewer/src/camera.rs
+++ b/sdl_viewer/src/camera.rs
@@ -153,7 +153,7 @@ impl Camera {
             self.pan += pan.normalize();
         }
 
-        let elapsed_seconds = elapsed.num_seconds() as f32;
+        let elapsed_seconds = elapsed.num_milliseconds() as f32 / 1000.;
 
         const TURNING_SPEED : Rad<f32> = Rad(0.15);
         if self.turning_left {

--- a/sdl_viewer/src/camera.rs
+++ b/sdl_viewer/src/camera.rs
@@ -153,7 +153,7 @@ impl Camera {
             self.pan += pan.normalize();
         }
 
-        let elapsed_seconds = elapsed.num_milliseconds() as f32 / 1000.;
+        let elapsed_seconds = elapsed.num_seconds() as f32;
 
         const TURNING_SPEED : Rad<f32> = Rad(0.15);
         if self.turning_left {

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -406,6 +406,7 @@ impl SdlViewer {
         let mut camera = Camera::new(&gl, WINDOW_WIDTH, WINDOW_HEIGHT);
 
         let mut events = ctx.event_pump().unwrap();
+        let mut last_frame_time = time::PreciseTime::now();
         'outer_loop: loop {
 
             for event in events.poll_iter() {
@@ -510,17 +511,19 @@ impl SdlViewer {
             }
 
             if let Some(j) = joystick.as_ref() {
-                let x = j.axis(0).unwrap() as f32 / 1000.;
-                let y = -j.axis(1).unwrap() as f32 / 1000.;
-                let z = -j.axis(2).unwrap() as f32 / 1000.;
-                let up = j.axis(3).unwrap() as f32 / 10000.;
+                let x = j.axis(0).unwrap() as f32 / 500.;
+                let y = -j.axis(1).unwrap() as f32 / 500.;
+                let z = -j.axis(2).unwrap() as f32 / 500.;
+                let up = j.axis(3).unwrap() as f32 / 500.;
                 // Combine tilting and turning on the knob.
-                let around = j.axis(4).unwrap() as f32 / 10000. - j.axis(5).unwrap() as f32 / 10000.;
+                let around = j.axis(4).unwrap() as f32 / 500. - j.axis(5).unwrap() as f32 / 500.;
                 camera.pan(x, y, z);
                 camera.rotate(up, around);
             }
-
-            if camera.update() {
+            let current_time = time::PreciseTime::now();
+            let elapsed = last_frame_time.to(current_time);
+            last_frame_time = current_time;
+            if camera.update(elapsed) {
                 renderer.camera_changed(&camera.get_world_to_gl());
             }
 


### PR DESCRIPTION
- Capture the elapsed time between two consecutive rendered frames.
- Incorporate the elapsed time in calculating the movement distance and rotation.