### PR TITLE
Restrict type roots to avoid conflicts with types in parent node_modules

### DIFF
--- a/xray/client/tsconfig.json
+++ b/xray/client/tsconfig.json
@@ -8,9 +8,18 @@
         "moduleResolution": "node",
         "outDir": "build",
         "module": "es6",
-        "lib": ["DOM", "ES6", "DOM.Iterable", "ScriptHost", "ES2017"]
+        "lib": [
+            "DOM",
+            "ES6",
+            "DOM.Iterable",
+            "ScriptHost",
+            "ES2017"
+        ],
+        "typeRoots": [
+            "./node_modules/@types"
+        ]
     },
     "files": [
-       "main.ts"
+        "main.ts"
     ]
 }


### PR DESCRIPTION
When the point cloud viewer is included in another repo as git subtree, the typescript compiler by default picks up types from all parent node_module directories, which can lead to conflicts and errors. This PR fixes these problems.