### PR TITLE
Octree refactoring to allow for more kinds of octree data sources.

### DIFF
--- a/octree_web_viewer/src/backend.rs
+++ b/octree_web_viewer/src/backend.rs
@@ -12,11 +12,11 @@ use std::sync::Arc;
 use time;
 
 pub struct VisibleNodes {
-    octree: Arc<dyn Octree>,
+    octree: Arc<Octree>,
 }
 
 impl VisibleNodes {
-    pub fn new(octree: Arc<dyn Octree>) -> Self {
+    pub fn new(octree: Arc<Octree>) -> Self {
         VisibleNodes { octree }
     }
 }
@@ -77,11 +77,11 @@ fn pad(input: &mut Vec<u8>) {
 }
 
 pub struct NodesData {
-    octree: Arc<dyn Octree>,
+    octree: Arc<Octree>,
 }
 
 impl NodesData {
-    pub fn new(octree: Arc<dyn Octree>) -> Self {
+    pub fn new(octree: Arc<Octree>) -> Self {
         NodesData { octree }
     }
 }

--- a/octree_web_viewer/src/bin/points_web_viewer.rs
+++ b/octree_web_viewer/src/bin/points_web_viewer.rs
@@ -66,12 +66,12 @@ fn main() {
 
     // The actix-web framework handles requests asynchronously using actors. If we need multi-threaded
     // write access to the Octree, instead of using an RwLock we should use the actor system.
-    let octree: Arc<dyn octree::Octree> = {
-        let web_octree = match octree::OnDiskOctree::new(octree_directory) {
-            Ok(web_octree) => web_octree,
+    let octree: Arc<octree::Octree> = {
+        let octree = match octree::octree_from_directory(octree_directory) {
+            Ok(octree) => octree,
             Err(err) => panic!("Could not load octree: {}", err),
         };
-        Arc::new(web_octree)
+        Arc::new(octree)
     };
 
     let sys = actix::System::new("octree-server");

--- a/point_viewer_grpc/src/bin/octree_benchmark.rs
+++ b/point_viewer_grpc/src/bin/octree_benchmark.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use point_viewer::octree::OnDiskOctree;
+use point_viewer::octree::octree_from_directory;
 use point_viewer::{InternalIterator, Point};
 use point_viewer_grpc::proto_grpc::OctreeClient;
 use point_viewer_grpc::service::start_grpc_server;
@@ -64,7 +64,7 @@ fn main() {
 }
 
 fn server_benchmark(octree_directory: PathBuf, num_points: u64) {
-    let octree = OnDiskOctree::new(&octree_directory).expect(&format!(
+    let octree = octree_from_directory(&octree_directory).expect(&format!(
         "Could not create octree from '{}'",
         octree_directory.display()
     ));

--- a/point_viewer_grpc/src/lib.rs
+++ b/point_viewer_grpc/src/lib.rs
@@ -13,28 +13,28 @@
 // limitations under the License.
 
 use crate::proto_grpc::OctreeClient;
-use cgmath::{Matrix4, Vector3};
+use cgmath::Vector3;
 use collision::Aabb3;
 use futures::{Future, Stream};
 use grpcio::{ChannelBuilder, EnvBuilder};
 use point_viewer::color::Color;
 use point_viewer::errors::*;
-use point_viewer::math::Cube;
-use point_viewer::octree::{NodeData, NodeId, NodeMeta, Octree, OnDiskOctree, PositionEncoding};
+use point_viewer::octree::{NodeId, NodeLayer, Octree, OctreeDataProvider};
+use point_viewer::proto::Meta;
 use point_viewer::Point;
 pub use point_viewer_grpc_proto_rust::proto;
 pub use point_viewer_grpc_proto_rust::proto_grpc;
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::io::{Cursor, Read};
 use std::sync::Arc;
 
 pub mod service;
 
-pub struct GrpcOctree {
+pub struct GrpcOctreeDataProvider {
     client: OctreeClient,
-    octree: OnDiskOctree,
 }
 
-impl GrpcOctree {
+impl GrpcOctreeDataProvider {
     pub fn new(addr: &str) -> Result<Self> {
         let env = Arc::new(EnvBuilder::new().build());
         let ch = ChannelBuilder::new(env)
@@ -42,12 +42,7 @@ impl GrpcOctree {
             .connect(addr);
         let client = OctreeClient::new(ch);
 
-        let reply = client
-            .get_meta(&proto::GetMetaRequest::new())
-            .map_err(|_| point_viewer::errors::ErrorKind::Grpc)?;
-        // TODO(sirver): We pass a dummy directory and hope we never actually use it for anything.
-        let octree = OnDiskOctree::from_meta(reply.meta.unwrap(), PathBuf::new())?;
-        Ok(GrpcOctree { client, octree })
+        Ok(GrpcOctreeDataProvider { client })
     }
 
     pub fn get_points_in_box(
@@ -108,32 +103,56 @@ impl GrpcOctree {
     }
 }
 
-impl Octree for GrpcOctree {
-    fn get_visible_nodes(&self, projection_matrix: &Matrix4<f32>) -> Vec<NodeId> {
-        self.octree.get_visible_nodes(projection_matrix)
+impl OctreeDataProvider for GrpcOctreeDataProvider {
+    fn meta_proto(&self) -> Result<Meta> {
+        let reply = self
+            .client
+            .get_meta(&proto::GetMetaRequest::new())
+            .map_err(|_| point_viewer::errors::ErrorKind::Grpc)?;
+        Ok(reply.meta.unwrap())
     }
 
-    fn get_node_data(&self, node_id: &NodeId) -> Result<NodeData> {
+    fn data(
+        &self,
+        node_id: &NodeId,
+        node_layers: Vec<NodeLayer>,
+    ) -> Result<HashMap<NodeLayer, Box<dyn Read>>> {
         let mut req = proto::GetNodeDataRequest::new();
         req.set_id(node_id.to_string());
-
-        // TODO(sirver): This should most definitively not crash, but instead return an error.
-        // Needs changes to the trait though.
         let reply = self
             .client
             .get_node_data(&req)
             .map_err(|_| point_viewer::errors::ErrorKind::Grpc)?;
-        let node = reply.node.unwrap();
-        let result = NodeData {
-            position: reply.position,
-            color: reply.color,
-            meta: NodeMeta {
-                num_points: node.num_points,
-                position_encoding: PositionEncoding::from_proto(node.position_encoding).unwrap(),
-                bounding_cube: node_id
-                    .find_bounding_cube(&Cube::bounding(&self.octree.bounding_box())),
-            },
-        };
-        Ok(result)
+        let mut readers = HashMap::<NodeLayer, Box<dyn Read>>::new();
+        for node_layer in node_layers {
+            let reader: Box<dyn Read> = match node_layer {
+                NodeLayer::Position => Box::new(Cursor::new(reply.position.clone())),
+                NodeLayer::Color => Box::new(Cursor::new(reply.color.clone())),
+                _ => {
+                    return Err("Unsupported node extension.".into());
+                }
+            };
+            readers.insert(node_layer.to_owned(), reader);
+        }
+        Ok(readers)
     }
+
+    fn number_of_points(&self, node_id: &NodeId) -> Result<i64> {
+        // TODO(mfeuerstein): We would need another proto to just get the number of nodes for one id.
+        for node_proto in self.meta_proto()?.nodes.iter() {
+            if *node_id
+                == NodeId::from_level_index(
+                    node_proto.id.as_ref().unwrap().level as u8,
+                    node_proto.id.as_ref().unwrap().index as usize,
+                )
+            {
+                return Ok(node_proto.num_points);
+            }
+        }
+        Err(ErrorKind::NodeNotFound.into())
+    }
+}
+
+pub fn octree_from_address(addr: &str) -> Result<Octree> {
+    Octree::new(Box::new(GrpcOctreeDataProvider::new(addr)?))
 }

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -21,7 +21,7 @@ use futures::{Future, Sink, Stream};
 use grpcio::{
     Environment, RpcContext, Server, ServerBuilder, ServerStreamingSink, UnarySink, WriteFlags,
 };
-use point_viewer::octree::{read_meta_proto, NodeId, Octree, OnDiskOctree};
+use point_viewer::octree::{octree_from_directory, read_meta_proto, NodeId, Octree};
 use point_viewer::{InternalIterator, Point};
 use protobuf::Message;
 use std::path::PathBuf;
@@ -29,7 +29,7 @@ use std::sync::Arc;
 
 #[derive(Clone)]
 struct OctreeService {
-    octree: Arc<OnDiskOctree>,
+    octree: Arc<Octree>,
     meta: point_viewer::proto::Meta,
 }
 
@@ -42,7 +42,7 @@ enum OctreeQuery {
 
 fn stream_points_back_to_sink(
     query: OctreeQuery,
-    octree: Arc<OnDiskOctree>,
+    octree: Arc<Octree>,
     ctx: RpcContext,
     resp: ServerStreamingSink<proto::PointsReply>,
 ) {
@@ -259,7 +259,7 @@ impl proto_grpc::Octree for OctreeService {
 pub fn start_grpc_server(octree_directory: PathBuf, host: &str, port: u16) -> Server {
     let env = Arc::new(Environment::new(1));
     let meta = read_meta_proto(&octree_directory).unwrap();
-    let octree = Arc::new(OnDiskOctree::new(octree_directory).unwrap());
+    let octree = Arc::new(octree_from_directory(octree_directory).unwrap());
 
     let service = proto_grpc::create_octree(OctreeService { octree, meta });
     let server = ServerBuilder::new(env)

--- a/sdl_viewer/src/bin/sdl_viewer.rs
+++ b/sdl_viewer/src/bin/sdl_viewer.rs
@@ -18,8 +18,7 @@ fn main() {
     SdlViewer::new()
         .register_octree_factory("grpc:".into(), |p| {
             Ok(Box::new(
-                point_viewer_grpc::GrpcOctree::new(p.as_str())
-                    .expect("Could not connect to GRPC server"),
+                point_viewer_grpc::octree_from_address(p.as_str()).expect("Could not create octree."),
             ))
         })
         .run();

--- a/sdl_viewer/src/bin/sdl_viewer.rs
+++ b/sdl_viewer/src/bin/sdl_viewer.rs
@@ -18,7 +18,8 @@ fn main() {
     SdlViewer::new()
         .register_octree_factory("grpc:".into(), |p| {
             Ok(Box::new(
-                point_viewer_grpc::octree_from_address(p.as_str()).expect("Could not create octree."),
+                point_viewer_grpc::octree_from_address(p.as_str())
+                    .expect("Could not create octree."),
             ))
         })
         .run();

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -364,7 +364,7 @@ impl SdlViewer {
         // If no octree was generated create an FromDisc loader
         let octree = Arc::new(octree_opt.unwrap_or_else(|| {
             pose_path = Some(PathBuf::from(&octree_argument).join("poses.json"));
-            Box::new(octree::OnDiskOctree::new(&octree_argument).unwrap()) as Box<Octree>
+            Box::new(octree::octree_from_directory(octree_argument).unwrap()) as Box<Octree>
         }));
 
         let ctx = sdl2::init().unwrap();

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -14,7 +14,7 @@
 
 use crate::errors::*;
 use crate::math::Cube;
-use crate::octree;
+use crate::octree::{self, OnDiskOctreeDataProvider};
 use crate::ply::PlyIterator;
 use crate::proto;
 use crate::pts::PtsIterator;
@@ -22,8 +22,6 @@ use crate::{InternalIterator, Point};
 use cgmath::{EuclideanSpace, Point3};
 use collision::{Aabb, Aabb3};
 use fnv::{FnvHashMap, FnvHashSet};
-use math::Cube;
-use octree::{self, OnDiskOctreeDataProvider};
 use pbr::ProgressBar;
 use protobuf::Message;
 use scoped_pool::{Pool, Scope};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,19 +26,19 @@ pub mod ply;
 pub mod pts;
 
 pub trait InternalIterator {
-  fn for_each<F: FnMut(&Point)>(self, _: F);
-  fn size_hint(&self) -> Option<usize>;
+    fn for_each<F: FnMut(&Point)>(self, _: F);
+    fn size_hint(&self) -> Option<usize>;
 }
 
 #[derive(Debug, Clone)]
 pub struct Point {
-  pub position: cgmath::Vector3<f32>,
-  // TODO(sirver): Make color optional, we might not always have it.
-  pub color: color::Color<u8>,
+    pub position: cgmath::Vector3<f32>,
+    // TODO(sirver): Make color optional, we might not always have it.
+    pub color: color::Color<u8>,
 
-  // The intensity of the point if it exists. This value is usually handed through directly by a
-  // sensor and has therefore no defined range - or even meaning.
-  pub intensity: Option<f32>,
+    // The intensity of the point if it exists. This value is usually handed through directly by a
+    // sensor and has therefore no defined range - or even meaning.
+    pub intensity: Option<f32>,
 }
 
 pub use point_viewer_proto_rust::proto;

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -21,22 +21,21 @@ use collision::{Aabb, Aabb3, Contains, Discrete, Frustum, Relation};
 use fnv::FnvHashMap;
 use protobuf;
 use std::cmp::Ordering;
-use std::collections::BinaryHeap;
-use std::fs::File;
+use std::collections::{BinaryHeap, HashMap};
+use std::fs::{self, File};
 use std::io::{BufReader, Cursor, Read};
 use std::path::{Path, PathBuf};
 
 mod node;
 
 pub use self::node::{
-    ChildIndex, Node, NodeId, NodeIterator, NodeMeta, NodeWriter, PositionEncoding,
+    ChildIndex, Node, NodeId, NodeIterator, NodeLayer, NodeMeta, NodeWriter, PositionEncoding,
 };
 
 pub const CURRENT_VERSION: i32 = 9;
 
 #[derive(Clone, Debug)]
 pub struct OctreeMeta {
-    pub directory: PathBuf,
     pub resolution: f64,
     pub bounding_box: Aabb3<f32>,
 }
@@ -80,18 +79,24 @@ fn relative_size_on_screen(bounding_cube: &Cube, matrix: &Matrix4<f32>) -> f32 {
     (rv.max().x - rv.min().x) * (rv.max().y - rv.min().y)
 }
 
-#[derive(Debug)]
-pub struct OnDiskOctree {
+pub trait OctreeDataProvider: Send + Sync {
+    fn meta_proto(&self) -> Result<proto::Meta>;
+    fn data(
+        &self,
+        node_id: &NodeId,
+        node_layers: Vec<NodeLayer>,
+    ) -> Result<HashMap<NodeLayer, Box<dyn Read>>>;
+    fn number_of_points(&self, node_id: &NodeId) -> Result<i64>;
+}
+
+pub struct Octree {
+    data_provider: Box<dyn OctreeDataProvider>,
     meta: OctreeMeta,
     nodes: FnvHashMap<NodeId, NodeMeta>,
 }
 
-pub trait Octree: Send + Sync {
-    fn get_visible_nodes(&self, projection_matrix: &Matrix4<f32>) -> Vec<NodeId>;
-    fn get_node_data(&self, node_id: &NodeId) -> Result<NodeData>;
-}
-
 pub struct PointsInBoxIterator<'a> {
+    octree_data_provider: &'a OctreeDataProvider,
     octree_meta: &'a OctreeMeta,
     aabb: &'a Aabb3<f32>,
     intersecting_nodes: Vec<NodeId>,
@@ -105,8 +110,12 @@ impl<'a> InternalIterator for PointsInBoxIterator<'a> {
     fn for_each<F: FnMut(&Point)>(self, mut f: F) {
         for node_id in &self.intersecting_nodes {
             // TODO(sirver): This crashes on error. We should bubble up an error.
-            let iterator = NodeIterator::from_disk(&self.octree_meta, node_id)
-                .expect("Could not read node points");
+            let iterator = NodeIterator::from_data_provider(
+                self.octree_data_provider,
+                self.octree_meta,
+                node_id,
+            )
+            .expect("Could not read node points");
             iterator.for_each(|p| {
                 if !self.aabb.contains(&Point3::from_vec(p.position)) {
                     return;
@@ -118,6 +127,7 @@ impl<'a> InternalIterator for PointsInBoxIterator<'a> {
 }
 
 pub struct PointsInFrustumIterator<'a> {
+    octree_data_provider: &'a OctreeDataProvider,
     octree_meta: &'a OctreeMeta,
     frustum_matrix: &'a Matrix4<f32>,
     intersecting_nodes: Vec<NodeId>,
@@ -130,8 +140,12 @@ impl<'a> InternalIterator for PointsInFrustumIterator<'a> {
 
     fn for_each<F: FnMut(&Point)>(self, mut f: F) {
         for node_id in &self.intersecting_nodes {
-            let iterator = NodeIterator::from_disk(&self.octree_meta, node_id)
-                .expect("Could not read node points");
+            let iterator = NodeIterator::from_data_provider(
+                self.octree_data_provider,
+                self.octree_meta,
+                node_id,
+            )
+            .expect("Could not read node points");
             iterator.for_each(|p| {
                 if !contains(self.frustum_matrix, &Point3::from_vec(p.position)) {
                     return;
@@ -143,6 +157,7 @@ impl<'a> InternalIterator for PointsInFrustumIterator<'a> {
 }
 
 pub struct AllPointsIterator<'a> {
+    octree_data_provider: &'a OctreeDataProvider,
     octree_meta: &'a OctreeMeta,
     octree_nodes: &'a FnvHashMap<NodeId, NodeMeta>,
 }
@@ -156,8 +171,12 @@ impl<'a> InternalIterator for AllPointsIterator<'a> {
         let mut open_list = vec![NodeId::from_level_index(0, 0)];
         while !open_list.is_empty() {
             let current = open_list.pop().unwrap();
-            let iterator = NodeIterator::from_disk(&self.octree_meta, &current)
-                .expect("Could not read node points");
+            let iterator = NodeIterator::from_data_provider(
+                self.octree_data_provider,
+                self.octree_meta,
+                &current,
+            )
+            .expect("Could not read node points");
             iterator.for_each(|p| f(p));
             for child_index in 0..8 {
                 let child_id = current.get_child_id(ChildIndex::from_u8(child_index));
@@ -200,9 +219,10 @@ pub struct NodeData {
     pub color: Vec<u8>,
 }
 
-impl OnDiskOctree {
+impl Octree {
     // TODO(sirver): This creates an object that is only partially usable.
-    pub fn from_meta(meta_proto: proto::Meta, directory: PathBuf) -> Result<Self> {
+    pub fn new(data_provider: Box<OctreeDataProvider>) -> Result<Self> {
+        let meta_proto = data_provider.meta_proto()?;
         if meta_proto.version != CURRENT_VERSION {
             return Err(ErrorKind::InvalidVersion(meta_proto.version).into());
         }
@@ -218,9 +238,8 @@ impl OnDiskOctree {
         };
 
         let meta = OctreeMeta {
-            directory: directory.into(),
             resolution: meta_proto.resolution,
-            bounding_box: bounding_box,
+            bounding_box,
         };
 
         let mut nodes = FnvHashMap::default();
@@ -238,13 +257,88 @@ impl OnDiskOctree {
                 },
             );
         }
-        Ok(OnDiskOctree { meta, nodes })
+
+        Ok(Octree {
+            meta,
+            nodes,
+            data_provider,
+        })
     }
 
-    pub fn new<P: AsRef<Path>>(directory: P) -> Result<Self> {
-        let directory = directory.as_ref().to_owned();
-        let meta_proto = read_meta_proto(&directory)?;
-        Self::from_meta(meta_proto, directory)
+    pub fn get_visible_nodes(&self, projection_matrix: &Matrix4<f32>) -> Vec<NodeId> {
+        let frustum = Frustum::from_matrix4(*projection_matrix).unwrap();
+        let mut open = BinaryHeap::new();
+        maybe_push_node(
+            &mut open,
+            &self.nodes,
+            Relation::Cross,
+            Node::root_with_bounding_cube(Cube::bounding(&self.meta.bounding_box)),
+            projection_matrix,
+        );
+
+        let mut visible = Vec::new();
+        while let Some(current) = open.pop() {
+            match current.relation {
+                Relation::Cross => {
+                    for child_index in 0..8 {
+                        let child = current.node.get_child(ChildIndex::from_u8(child_index));
+                        let child_relation = frustum.contains(&child.bounding_cube.to_aabb3());
+                        if child_relation == Relation::Out {
+                            continue;
+                        }
+                        maybe_push_node(
+                            &mut open,
+                            &self.nodes,
+                            child_relation,
+                            child,
+                            projection_matrix,
+                        );
+                    }
+                }
+                Relation::In => {
+                    // When the parent is fully in the frustum, so are the children.
+                    for child_index in 0..8 {
+                        maybe_push_node(
+                            &mut open,
+                            &self.nodes,
+                            Relation::In,
+                            current.node.get_child(ChildIndex::from_u8(child_index)),
+                            projection_matrix,
+                        );
+                    }
+                }
+                Relation::Out => {
+                    // This should never happen.
+                    unreachable!();
+                }
+            };
+            visible.push(current.node.id);
+        }
+        visible
+    }
+
+    pub fn get_node_data(&self, node_id: &NodeId) -> Result<NodeData> {
+        // TODO(hrapp): If we'd randomize the points while writing, we could just read the
+        // first N points instead of reading everything and skipping over a few.
+        let mut position_color_reads = self
+            .data_provider
+            .data(node_id, vec![NodeLayer::Position, NodeLayer::Color])?;
+
+        let mut get_data = |node_layer: &NodeLayer, err: &str| -> Result<Vec<u8>> {
+            let mut reader =
+                BufReader::new(position_color_reads.remove(node_layer).ok_or_else(|| err)?);
+            let mut all_data = Vec::new();
+            reader.read_to_end(&mut all_data).chain_err(|| err)?;
+            Ok(all_data)
+        };
+        let position = get_data(&NodeLayer::Position, "Could not read position")?;
+        let color = get_data(&NodeLayer::Color, "Could not read color")?;
+
+        Ok(NodeData {
+            position: position,
+            color: color,
+            meta: self.nodes[node_id].clone(),
+        })
     }
 
     /// Returns the ids of all nodes that cut or are fully contained in 'aabb'.
@@ -267,6 +361,7 @@ impl OnDiskOctree {
             }
         }
         PointsInBoxIterator {
+            octree_data_provider: &*self.data_provider,
             octree_meta: &self.meta,
             aabb,
             intersecting_nodes,
@@ -279,6 +374,7 @@ impl OnDiskOctree {
     ) -> PointsInFrustumIterator<'a> {
         let intersecting_nodes = self.get_visible_nodes(&frustum_matrix);
         PointsInFrustumIterator {
+            octree_data_provider: &*self.data_provider,
             octree_meta: &self.meta,
             frustum_matrix,
             intersecting_nodes,
@@ -287,6 +383,7 @@ impl OnDiskOctree {
 
     pub fn all_points<'a>(&'a self) -> AllPointsIterator<'a> {
         AllPointsIterator {
+            octree_data_provider: &*self.data_provider,
             octree_meta: &self.meta,
             octree_nodes: &self.nodes,
         }
@@ -349,90 +446,56 @@ fn maybe_push_node(
     });
 }
 
-impl Octree for OnDiskOctree {
-    fn get_visible_nodes(&self, projection_matrix: &Matrix4<f32>) -> Vec<NodeId> {
-        let frustum = Frustum::from_matrix4(*projection_matrix).unwrap();
-        let mut open = BinaryHeap::new();
-        maybe_push_node(
-            &mut open,
-            &self.nodes,
-            Relation::Cross,
-            Node::root_with_bounding_cube(Cube::bounding(&self.meta.bounding_box)),
-            projection_matrix,
-        );
+pub struct OnDiskOctreeDataProvider {
+    pub directory: PathBuf,
+}
 
-        let mut visible = Vec::new();
-        while let Some(current) = open.pop() {
-            match current.relation {
-                Relation::Cross => {
-                    for child_index in 0..8 {
-                        let child = current.node.get_child(ChildIndex::from_u8(child_index));
-                        let child_relation = frustum.contains(&child.bounding_cube.to_aabb3());
-                        if child_relation == Relation::Out {
-                            continue;
-                        }
-                        maybe_push_node(
-                            &mut open,
-                            &self.nodes,
-                            child_relation,
-                            child,
-                            projection_matrix,
-                        );
-                    }
-                }
-                Relation::In => {
-                    // When the parent is fully in the frustum, so are the children.
-                    for child_index in 0..8 {
-                        maybe_push_node(
-                            &mut open,
-                            &self.nodes,
-                            Relation::In,
-                            current.node.get_child(ChildIndex::from_u8(child_index)),
-                            projection_matrix,
-                        );
-                    }
-                }
-                Relation::Out => {
-                    // This should never happen.
-                    unreachable!();
-                }
-            };
-            visible.push(current.node.id);
-        }
-        visible
+impl OnDiskOctreeDataProvider {
+    /// Returns the path on disk where the data for this node is saved.
+    pub fn stem(&self, node_id: &NodeId) -> PathBuf {
+        self.directory.join(node_id.to_string())
+    }
+}
+
+impl OctreeDataProvider for OnDiskOctreeDataProvider {
+    fn meta_proto(&self) -> Result<proto::Meta> {
+        read_meta_proto(&self.directory)
     }
 
-    fn get_node_data(&self, node_id: &NodeId) -> Result<NodeData> {
-        let stem = node_id.get_stem(&self.meta.directory);
-
-        // TODO(hrapp): If we'd randomize the points while writing, we could just read the
-        // first N points instead of reading everything and skipping over a few.
-        let position = {
-            let mut xyz_reader =
-                BufReader::new(File::open(&stem.with_extension(node::POSITION_EXT))?);
-            let mut all_data = Vec::new();
-            xyz_reader
-                .read_to_end(&mut all_data)
-                .chain_err(|| "Could not read position")?;
-            all_data
-        };
-
-        let color = {
-            let mut rgb_reader = BufReader::new(
-                File::open(&stem.with_extension(node::COLOR_EXT))
-                    .chain_err(|| "Could not read color")?,
+    fn data(
+        &self,
+        node_id: &NodeId,
+        node_layers: Vec<NodeLayer>,
+    ) -> Result<HashMap<NodeLayer, Box<dyn Read>>> {
+        let stem = self.stem(node_id);
+        let mut readers = HashMap::<NodeLayer, Box<dyn Read>>::new();
+        for node_layer in node_layers {
+            readers.insert(
+                node_layer.to_owned(),
+                Box::new(File::open(&stem.with_extension(node_layer.extension()))?),
             );
-            let mut all_data = Vec::new();
-            rgb_reader
-                .read_to_end(&mut all_data)
-                .chain_err(|| "Could not read color")?;
-            all_data
-        };
-
-        Ok(NodeData {
-            position: position,
-            color: color,
-            meta: self.nodes[node_id].clone(),
-        })
+        }
+        Ok(readers)
     }
+
+    // Get number of points from the file size of the color data.
+    // Color data is required and always present.
+    fn number_of_points(&self, node_id: &NodeId) -> Result<i64> {
+        let stem = self.stem(node_id);
+        let file_meta_data_opt = fs::metadata(stem.with_extension(NodeLayer::Color.extension()));
+        if file_meta_data_opt.is_err() {
+            return Err(ErrorKind::NodeNotFound.into());
+        }
+
+        let file_size_bytes = file_meta_data_opt.unwrap().len();
+        // color has 3 bytes per point
+        Ok((file_size_bytes / 3) as i64)
+    }
+}
+
+pub fn octree_from_directory(directory: impl Into<PathBuf>) -> Result<Octree> {
+    let data_provider = OnDiskOctreeDataProvider {
+        directory: directory.into(),
+    };
+    Octree::new(Box::new(data_provider))
 }

--- a/src/octree/node.rs
+++ b/src/octree/node.rs
@@ -22,14 +22,29 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use cgmath::{Vector3, Zero};
 use num;
 use num_traits;
+use octree::{OctreeDataProvider, OctreeMeta, OnDiskOctreeDataProvider};
+use proto;
 use std::fs::{self, File};
-use std::io::{BufReader, BufWriter};
-use std::path::{Path, PathBuf};
+use std::io::{BufReader, BufWriter, Read};
+use std::path::PathBuf;
 use std::{fmt, result};
 
-pub const POSITION_EXT: &str = "xyz";
-pub const COLOR_EXT: &str = "rgb";
-pub const INTENSITY_EXT: &str = "intensity";
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum NodeLayer {
+    Position,
+    Color,
+    Intensity,
+}
+
+impl NodeLayer {
+    pub fn extension(&self) -> &str {
+        match self {
+            NodeLayer::Position => "xyz",
+            NodeLayer::Color => "rgb",
+            NodeLayer::Intensity => "intensity",
+        }
+    }
+}
 
 /// Represents a child of an octree Node.
 #[derive(Debug, PartialEq, Eq)]
@@ -100,11 +115,6 @@ impl NodeId {
         NodeId { level, index }
     }
 
-    /// Returns the path on disk where the data for this node is saved.
-    pub fn get_stem(&self, directory: &Path) -> PathBuf {
-        directory.join(&self.to_string())
-    }
-
     /// Returns the root node of the octree.
     fn root() -> Self {
         NodeId { index: 0, level: 0 }
@@ -164,19 +174,6 @@ impl NodeId {
             min.z += z as f32 * edge_length;
         }
         Cube::new(min, edge_length)
-    }
-
-    // Get number of points from the file size of the color data.
-    // Color data is required and always present.
-    fn number_of_points(&self, directory: &Path) -> Result<i64> {
-        let file_meta_data_opt = fs::metadata(self.get_stem(directory).with_extension(COLOR_EXT));
-        if file_meta_data_opt.is_err() {
-            return Err(ErrorKind::NodeNotFound.into());
-        }
-
-        let file_size_bytes = file_meta_data_opt.unwrap().len();
-        // color has 3 bytes per point
-        Ok((file_size_bytes / 3) as i64)
     }
 }
 
@@ -267,32 +264,50 @@ impl NodeMeta {
     }
 }
 
-/// Streams points from our node on-disk representation.
+/// Streams points from our data provider representation.
 pub struct NodeIterator {
-    xyz_reader: BufReader<File>,
-    rgb_reader: BufReader<File>,
-    intensity_reader: Option<BufReader<File>>,
+    xyz_reader: BufReader<Box<dyn Read>>,
+    rgb_reader: BufReader<Box<dyn Read>>,
+    intensity_reader: Option<BufReader<Box<dyn Read>>>,
     meta: NodeMeta,
 }
 
 impl NodeIterator {
-    pub fn from_disk(octree_meta: &OctreeMeta, id: &NodeId) -> Result<Self> {
-        let stem = id.get_stem(&octree_meta.directory);
-        let num_points = id.number_of_points(&octree_meta.directory)?;
+    pub fn from_data_provider(
+        octree_data_provider: &OctreeDataProvider,
+        octree_meta: &OctreeMeta,
+        id: &NodeId,
+    ) -> Result<Self> {
         let bounding_cube = id.find_bounding_cube(&Cube::bounding(&octree_meta.bounding_box));
         let position_encoding = PositionEncoding::new(&bounding_cube, octree_meta.resolution);
-        let intensity_reader = File::open(&stem.with_extension(INTENSITY_EXT))
-            .map(|f| Some(BufReader::new(f)))
-            .unwrap_or(None);
+        let intensity_reader = match octree_data_provider.data(id, vec![NodeLayer::Intensity]) {
+            Ok(mut data_map) => match data_map.remove(&NodeLayer::Intensity) {
+                Some(intensity_data) => Some(BufReader::new(intensity_data)),
+                None => {
+                    return Err("No intensity reader available.".into());
+                }
+            },
+            Err(_) => None,
+        };
 
+        let mut position_color_reads =
+            octree_data_provider.data(id, vec![NodeLayer::Position, NodeLayer::Color])?;
         Ok(NodeIterator {
-            xyz_reader: BufReader::new(File::open(&stem.with_extension(POSITION_EXT))?),
-            rgb_reader: BufReader::new(File::open(&stem.with_extension(COLOR_EXT))?),
+            xyz_reader: BufReader::new(
+                position_color_reads
+                    .remove(&NodeLayer::Position)
+                    .ok_or_else(|| "No position reader available.")?,
+            ),
+            rgb_reader: BufReader::new(
+                position_color_reads
+                    .remove(&NodeLayer::Color)
+                    .ok_or_else(|| "No color reader available.")?,
+            ),
             intensity_reader,
             meta: NodeMeta {
                 bounding_cube: bounding_cube,
                 position_encoding: position_encoding,
-                num_points: num_points,
+                num_points: octree_data_provider.number_of_points(id)?,
             },
         })
     }
@@ -469,12 +484,20 @@ impl Drop for NodeWriter {
 }
 
 impl NodeWriter {
-    pub fn new(octree_meta: &OctreeMeta, node_id: &NodeId) -> Self {
-        let stem = node_id.get_stem(&octree_meta.directory);
+    pub fn new(
+        octree_data_provider: &OnDiskOctreeDataProvider,
+        octree_meta: &OctreeMeta,
+        node_id: &NodeId,
+    ) -> Self {
+        let stem = octree_data_provider.stem(node_id);
         let bounding_cube = node_id.find_bounding_cube(&Cube::bounding(&octree_meta.bounding_box));
         NodeWriter {
-            xyz_writer: BufWriter::new(File::create(&stem.with_extension(POSITION_EXT)).unwrap()),
-            rgb_writer: BufWriter::new(File::create(&stem.with_extension(COLOR_EXT)).unwrap()),
+            xyz_writer: BufWriter::new(
+                File::create(&stem.with_extension(NodeLayer::Position.extension())).unwrap(),
+            ),
+            rgb_writer: BufWriter::new(
+                File::create(&stem.with_extension(NodeLayer::Color.extension())).unwrap(),
+            ),
             intensity_writer: None, // Will be created if needed on first point with intensities.
             stem: stem,
             position_encoding: PositionEncoding::new(&bounding_cube, octree_meta.resolution),
@@ -533,7 +556,8 @@ impl NodeWriter {
         if let Some(intensity) = p.intensity {
             if self.intensity_writer.is_none() {
                 self.intensity_writer = Some(BufWriter::new(
-                    File::create(&self.stem.with_extension(INTENSITY_EXT)).unwrap(),
+                    File::create(&self.stem.with_extension(NodeLayer::Intensity.extension()))
+                        .unwrap(),
                 ));
             }
             self.intensity_writer
@@ -552,8 +576,8 @@ impl NodeWriter {
 
     fn remove_all_files(&self) {
         // We are ignoring deletion errors here in case the file is already gone.
-        let _ = fs::remove_file(&self.stem.with_extension(POSITION_EXT));
-        let _ = fs::remove_file(&self.stem.with_extension(COLOR_EXT));
+        let _ = fs::remove_file(&self.stem.with_extension(NodeLayer::Position.extension()));
+        let _ = fs::remove_file(&self.stem.with_extension(NodeLayer::Color.extension()));
     }
 }
 

--- a/src/octree/node.rs
+++ b/src/octree/node.rs
@@ -15,15 +15,13 @@
 use crate::color;
 use crate::errors::*;
 use crate::math::{clamp, Cube};
-use crate::octree::OctreeMeta;
+use crate::octree::{OctreeDataProvider, OctreeMeta, OnDiskOctreeDataProvider};
 use crate::proto;
 use crate::{InternalIterator, Point};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use cgmath::{Vector3, Zero};
 use num;
 use num_traits;
-use octree::{OctreeDataProvider, OctreeMeta, OnDiskOctreeDataProvider};
-use proto;
 use std::fs::{self, File};
 use std::io::{BufReader, BufWriter, Read};
 use std::path::PathBuf;

--- a/xray/src/bin/build_xray_quadtree.rs
+++ b/xray/src/bin/build_xray_quadtree.rs
@@ -1,5 +1,4 @@
 use clap::value_t;
-use point_viewer::octree;
 use point_viewer::octree::octree_from_directory;
 use scoped_pool::Pool;
 use std::path::Path;

--- a/xray/src/bin/build_xray_quadtree.rs
+++ b/xray/src/bin/build_xray_quadtree.rs
@@ -1,6 +1,6 @@
-use crate::octree::OnDiskOctree;
 use clap::value_t;
 use point_viewer::octree;
+use point_viewer::octree::octree_from_directory;
 use scoped_pool::Pool;
 use std::path::Path;
 use xray::generation::{ColoringStrategyArgument, ColoringStrategyKind};
@@ -98,7 +98,7 @@ pub fn main() {
     let output_directory = Path::new(args.value_of("output_directory").unwrap());
 
     let pool = Pool::new(10);
-    let octree = OnDiskOctree::new(octree_directory).expect("Could not open octree.");
+    let octree = octree_from_directory(octree_directory).expect("Could not open octree.");
     xray::generation::build_xray_quadtree(
         &pool,
         &octree,

--- a/xray/src/bin/build_xray_tile.rs
+++ b/xray/src/bin/build_xray_tile.rs
@@ -2,7 +2,7 @@ use crate::octree::OnDiskOctree;
 use cgmath::{Point2, Point3};
 use clap::value_t;
 use collision::{Aabb, Aabb2, Aabb3};
-use point_viewer::octree;
+use point_viewer::octree::octree_from_directory;
 use std::error::Error;
 use std::path::Path;
 use xray::generation::{xray_from_points, ColoringStrategyArgument, ColoringStrategyKind};
@@ -87,7 +87,7 @@ fn run(
     coloring_strategy_kind: ColoringStrategyKind,
     bbox2: &Aabb2<f32>,
 ) -> Result<(), Box<Error>> {
-    let octree = &OnDiskOctree::new(octree_directory)?;
+    let octree = &octree_from_directory(octree_directory)?;
     let bbox3 = octree.bounding_box();
     let bbox3 = Aabb3::new(
         Point3::new(

--- a/xray/src/bin/build_xray_tile.rs
+++ b/xray/src/bin/build_xray_tile.rs
@@ -1,4 +1,3 @@
-use crate::octree::OnDiskOctree;
 use cgmath::{Point2, Point3};
 use clap::value_t;
 use collision::{Aabb, Aabb2, Aabb3};

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -358,7 +358,7 @@ impl ColoringStrategy for HeightStddevColoringStrategy {
 }
 
 pub fn xray_from_points(
-    octree: &octree::OnDiskOctree,
+    octree: &octree::Octree,
     bbox: &Aabb3<f32>,
     png_file: &Path,
     image_width: u32,
@@ -421,7 +421,7 @@ pub fn get_image_path(directory: &Path, id: NodeId) -> PathBuf {
 
 pub fn build_xray_quadtree(
     pool: &Pool,
-    octree: &octree::OnDiskOctree,
+    octree: &octree::Octree,
     output_directory: &Path,
     resolution: f32,
     tile_size_px: u32,


### PR DESCRIPTION
This PR changes how an octree is constructed. The octree itself is not a trait anymore, but it contains an octree data provider trait. This is necessary in order to add other data sources such as cloud data storage.