### PR TITLE
Iterator refactoring.

### DIFF
--- a/point_viewer_grpc/src/lib.rs
+++ b/point_viewer_grpc/src/lib.rs
@@ -136,21 +136,6 @@ impl OctreeDataProvider for GrpcOctreeDataProvider {
         }
         Ok(readers)
     }
-
-    fn number_of_points(&self, node_id: &NodeId) -> Result<i64> {
-        // TODO(mfeuerstein): We would need another proto to just get the number of nodes for one id.
-        for node_proto in self.meta_proto()?.nodes.iter() {
-            if *node_id
-                == NodeId::from_level_index(
-                    node_proto.id.as_ref().unwrap().level as u8,
-                    node_proto.id.as_ref().unwrap().index as usize,
-                )
-            {
-                return Ok(node_proto.num_points);
-            }
-        }
-        Err(ErrorKind::NodeNotFound.into())
-    }
 }
 
 pub fn octree_from_address(addr: &str) -> Result<Octree> {

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -139,6 +139,7 @@ fn split_node<'a, P>(
                 octree_data_provider,
                 octree_meta,
                 &child_id,
+                octree_data_provider.number_of_points(&child_id).unwrap(),
             )
             .unwrap();
             split_node(
@@ -170,6 +171,7 @@ fn subsample_children_into(
             octree_data_provider,
             octree_meta,
             &child_id,
+            octree_data_provider.number_of_points(&child_id)?,
         ) {
             Ok(node_iterator) => node_iterator,
             Err(Error(ErrorKind::NodeNotFound, _)) => continue,

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -357,7 +357,7 @@ impl Octree {
             }
         }
         PointsInBoxIterator {
-            octree: &*self,
+            octree: &self,
             aabb,
             intersecting_nodes,
         }
@@ -369,7 +369,7 @@ impl Octree {
     ) -> PointsInFrustumIterator<'a> {
         let intersecting_nodes = self.get_visible_nodes(&frustum_matrix);
         PointsInFrustumIterator {
-            octree: &*self,
+            octree: &self,
             frustum_matrix,
             intersecting_nodes,
         }
@@ -377,7 +377,7 @@ impl Octree {
 
     pub fn all_points(&self) -> AllPointsIterator {
         AllPointsIterator {
-            octree: &*self,
+            octree: &self,
             octree_nodes: &self.nodes,
         }
     }

--- a/src/octree/node.rs
+++ b/src/octree/node.rs
@@ -276,7 +276,7 @@ pub struct NodeIterator {
 
 impl NodeIterator {
     pub fn from_data_provider(
-        octree_data_provider: &OctreeDataProvider,
+        octree_data_provider: &dyn OctreeDataProvider,
         octree_meta: &OctreeMeta,
         id: &NodeId,
         num_points: i64,

--- a/src/octree/node.rs
+++ b/src/octree/node.rs
@@ -279,6 +279,7 @@ impl NodeIterator {
         octree_data_provider: &OctreeDataProvider,
         octree_meta: &OctreeMeta,
         id: &NodeId,
+        num_points: i64,
     ) -> Result<Self> {
         let bounding_cube = id.find_bounding_cube(&Cube::bounding(&octree_meta.bounding_box));
         let position_encoding = PositionEncoding::new(&bounding_cube, octree_meta.resolution);
@@ -309,7 +310,7 @@ impl NodeIterator {
             meta: NodeMeta {
                 bounding_cube,
                 position_encoding,
-                num_points: octree_data_provider.number_of_points(id)?,
+                num_points,
             },
         })
     }


### PR DESCRIPTION
This speeds up node iterator generation for already completed octrees and simplifies the OctreeDataProvider trait by removing the `num_points` method.