### PR TITLE
Fix octree generation.

### DIFF
--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -466,7 +466,6 @@ impl OctreeDataProvider for OnDiskOctreeDataProvider {
         let stem = self.stem(node_id);
         let mut readers = HashMap::<NodeLayer, Box<dyn Read>>::new();
         for node_layer in node_layers {
-            let foo = &stem.with_extension(node_layer.extension());
             let file = match File::open(&stem.with_extension(node_layer.extension())) {
                 Err(ref err) if err.kind() == ::std::io::ErrorKind::NotFound => {
                     return Err(ErrorKind::NodeNotFound.into());

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -466,10 +466,14 @@ impl OctreeDataProvider for OnDiskOctreeDataProvider {
         let stem = self.stem(node_id);
         let mut readers = HashMap::<NodeLayer, Box<dyn Read>>::new();
         for node_layer in node_layers {
-            readers.insert(
-                node_layer.to_owned(),
-                Box::new(File::open(&stem.with_extension(node_layer.extension()))?),
-            );
+            let foo = &stem.with_extension(node_layer.extension());
+            let file = match File::open(&stem.with_extension(node_layer.extension())) {
+                Err(ref err) if err.kind() == ::std::io::ErrorKind::NotFound => {
+                    return Err(ErrorKind::NodeNotFound.into());
+                }
+                e => e,
+            }?;
+            readers.insert(node_layer.to_owned(), Box::new(file));
         }
         Ok(readers)
     }

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -8,10 +8,7 @@ use collision::{Aabb, Aabb3};
 use fnv::{FnvHashMap, FnvHashSet};
 use image::{self, GenericImage};
 use point_viewer::math::clamp;
-use point_viewer::{
-    color::Color,
-    octree, InternalIterator, Point,
-};
+use point_viewer::{color::Color, octree, InternalIterator, Point};
 use protobuf::Message;
 use quadtree::{ChildIndex, Node, NodeId, Rect};
 use scoped_pool::Pool;
@@ -303,7 +300,10 @@ impl HeightStddevColoringStrategy {
 /// Build a parent image created of the 4 children tiles. All tiles are optionally, in which case
 /// they are left white in the resulting image. The input images must be square with length N,
 /// the returned image is square with length 2*N.
-pub fn build_parent(children: &[Option<image::RgbaImage>], tile_background_color: Color<u8>) -> image::RgbaImage {
+pub fn build_parent(
+    children: &[Option<image::RgbaImage>],
+    tile_background_color: Color<u8>,
+) -> image::RgbaImage {
     assert_eq!(children.len(), 4);
     let mut child_size_px = None;
     for c in children.iter() {
@@ -441,7 +441,7 @@ pub fn build_xray_quadtree(
     resolution: f32,
     tile_size_px: u32,
     coloring_strategy_kind: &ColoringStrategyKind,
-    tile_background_color: Color<u8>
+    tile_background_color: Color<u8>,
 ) -> Result<(), Box<Error>> {
     // Ignore errors, maybe directory is already there.
     let _ = fs::create_dir(output_directory);
@@ -483,7 +483,7 @@ pub fn build_xray_quadtree(
                         tile_size_px,
                         tile_size_px,
                         strategy,
-                        tile_background_color
+                        tile_background_color,
                     ) {
                         all_nodes_tx_clone.send(node.id).unwrap();
                         if let Some(id) = node.id.parent_id() {


### PR DESCRIPTION
On octree generation, parent nodes are generated by subsampling from their children. The code is checking for all 8 potential children, expecting that the NodeIterator correctly returns `NodeNotFound` if a node does not exist.

However the OnDiskDataProvider returned `std::io::ErrorKind::NotFound` instead, which was taken as a hard error, ending octree generation.