### PR TITLE
Parallelize the octree server

### DIFF
--- a/point_viewer_grpc/src/bin/octree_benchmark.rs
+++ b/point_viewer_grpc/src/bin/octree_benchmark.rs
@@ -11,14 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-extern crate clap;
-extern crate futures;
-extern crate grpcio;
-extern crate point_viewer;
-extern crate point_viewer_grpc;
-extern crate point_viewer_grpc_proto_rust;
-
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::thread;
@@ -82,11 +75,11 @@ fn main() {
     let rspcq = usize::from_str(matches.value_of("rspcq").unwrap_or("1"))
         .expect("rspcq needs to be a number");
     if matches.is_present("no-client") {
-        server_benchmark(octree_directory, num_points, num_threads)
+        server_benchmark(&octree_directory, num_points, num_threads)
     } else {
         let port = value_t!(matches, "port", u16).unwrap_or(50051);
         full_benchmark(
-            octree_directory,
+            &octree_directory,
             num_points,
             port,
             num_threads,
@@ -96,10 +89,10 @@ fn main() {
     }
 }
 
-fn server_benchmark(octree_directory: PathBuf, num_points: u64, num_threads: u64) {
+fn server_benchmark(octree_directory: &Path, num_points: u64, num_threads: u64) {
     let mut handles = Vec::with_capacity(num_threads as usize);
     for i in 0..num_threads {
-        let octree = octree_from_directory(&octree_directory).expect(&format!(
+        let octree = octree_from_directory(octree_directory).expect(&format!(
             "Could not create octree from '{}'",
             octree_directory.display()
         ));
@@ -125,7 +118,7 @@ fn server_benchmark(octree_directory: PathBuf, num_points: u64, num_threads: u64
 }
 
 fn full_benchmark(
-    octree_directory: PathBuf,
+    octree_directory: &Path,
     num_points: u64,
     port: u16,
     num_threads: u64,
@@ -136,7 +129,7 @@ fn full_benchmark(
         cq_count: cq_count,
         requests_slot_per_cq: rspcq,
     };
-    let mut server = start_grpc_server(&octree_directory, "0.0.0.0", port, &opts);
+    let mut server = start_grpc_server(octree_directory, "0.0.0.0", port, &opts);
 
     server.start();
 

--- a/point_viewer_grpc/src/bin/octree_benchmark.rs
+++ b/point_viewer_grpc/src/bin/octree_benchmark.rs
@@ -23,6 +23,7 @@ use point_viewer_grpc_proto_rust::proto;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::thread;
 
 use futures::future::Future;
 use futures::Stream;
@@ -43,6 +44,22 @@ fn main() {
                 .help("Do not actually send points, only read them on the server.")
                 .long("no-client")
                 .takes_value(false),
+            clap::Arg::with_name("num-threads")
+                .help("The number of concurrent requests to split the query into.")
+                .long("num-threads")
+                .takes_value(true),
+            clap::Arg::with_name("cq-count")
+                .help("The number of concurrent requests to split the query into.")
+                .long("cq-count")
+                .takes_value(true),
+            clap::Arg::with_name("rspcq")
+                .help("The number of concurrent requests to split the query into.")
+                .long("rspcq")
+                .takes_value(true),
+            clap::Arg::with_name("cq-count-client")
+                .help("The number of concurrent requests to split the query into.")
+                .long("cq-count-client")
+                .takes_value(true),
             clap::Arg::with_name("num-points")
                 .help("Number of points to stream. [50000000]")
                 .long("num-points")
@@ -61,54 +78,81 @@ fn main() {
     );
     let num_points = u64::from_str(matches.value_of("num-points").unwrap_or("50000000"))
         .expect("num-points needs to be a number");
+    let num_threads = u64::from_str(matches.value_of("num-threads").unwrap_or("1"))
+        .expect("num-threads needs to be a number");
+    let cq_count = usize::from_str(matches.value_of("cq-count").unwrap_or("1"))
+        .expect("cq-count needs to be a number");
+    let rspcq = usize::from_str(matches.value_of("rspcq").unwrap_or("1"))
+        .expect("rspcq needs to be a number");
+    let cq_count_client = usize::from_str(matches.value_of("cq-count-client").unwrap_or("1"))
+        .expect("cq-count-client needs to be a number");
     if matches.is_present("no-client") {
-        server_benchmark(octree_directory, num_points)
+        server_benchmark(octree_directory, num_points, num_threads)
     } else {
         let port = value_t!(matches, "port", u16).unwrap_or(50051);
-        full_benchmark(octree_directory, num_points, port)
+        full_benchmark(octree_directory, num_points, port, num_threads, cq_count, rspcq, cq_count_client)
     }
 }
 
-fn server_benchmark(octree_directory: PathBuf, num_points: u64) {
-    let octree = OnDiskOctree::new(&octree_directory).expect(&format!(
-        "Could not create octree from '{}'",
-        octree_directory.display()
-    ));
-    let mut counter: u64 = 0;
-    octree.all_points().for_each(|_p: &Point| {
-        if counter % 1000000 == 0 {
-            println!("Streamed {}M points", counter / 1000000);
-        }
-        counter += 1;
-        if counter == num_points {
-            std::process::exit(0)
-        }
-    });
+
+fn server_benchmark(octree_directory: PathBuf, num_points: u64, num_threads: u64) {
+    let mut handles = Vec::with_capacity(num_threads as usize);
+    for i in 0..num_threads {
+        let octree = OnDiskOctree::new(&octree_directory).expect(&format!(
+            "Could not create octree from '{}'",
+            octree_directory.display()
+        ));
+
+        handles.push(thread::spawn(move || {
+            let mut counter: u64 = 0;
+            octree.all_points(i as i32, num_threads as i32).for_each(|_p: &Point| {
+                if counter % 1000000 == 0 {
+                    println!("Streamed {}M points", counter / 1000000);
+                }
+                counter += 1;
+                if counter == num_points/num_threads {
+                    std::process::exit(0)
+                }
+            });
+        }));
+    };
+    for handle in handles {
+        handle.join().unwrap();
+    }
 }
 
-fn full_benchmark(octree_directory: PathBuf, num_points: u64, port: u16) {
-    let mut server = start_grpc_server(octree_directory, "0.0.0.0", port);
+
+fn full_benchmark(octree_directory: PathBuf, num_points: u64, port: u16, num_threads: u64, cq_count: usize, rspcq: usize, cq_count_client: usize) {
+    let mut server = start_grpc_server(octree_directory, "0.0.0.0", port, cq_count, rspcq);
     server.start();
 
-    let env = Arc::new(Environment::new(1));
+    let env = Arc::new(Environment::new(cq_count_client));
     let ch = ChannelBuilder::new(env).connect(&format!("localhost:{}", port));
-    let client = OctreeClient::new(ch);
 
-    let req = proto::GetAllPointsRequest::new();
-    let receiver = client.get_all_points(&req).unwrap();
-
+    let mut handles = Vec::with_capacity(num_threads as usize);
     let mut counter: u64 = 0;
-
-    'outer: for rep in receiver.wait() {
-        for _pos in rep.expect("Stream error").get_positions().iter() {
-            if counter % 1000000 == 0 {
-                println!("Streamed {}M points", counter / 1000000);
+    for i in 0..num_threads {
+        let client = OctreeClient::new(ch.clone());
+        handles.push(thread::Builder::new().name(format!("client {}", i)).spawn(move || {
+            let mut req = proto::GetAllPointsParallelRequest::new();
+            req.set_reqIndex(i as i32);
+            req.set_total(num_threads as i32);
+            let receiver = client.get_all_points_parallel(&req).unwrap();
+            'outer: for rep in receiver.wait() {
+                for _pos in rep.expect("Stream error").get_positions().iter() {
+                    if counter % 1000000 == 0 {
+                        println!("Streamed {}M points", counter / 1000000);
+                    }
+                    counter += 1;
+                    if counter == num_points/num_threads {
+                        break 'outer;
+                    }
+                }
             }
-            counter += 1;
-            if counter == num_points {
-                break 'outer;
-            }
-        }
+        }).unwrap());
+    };
+    for handle in handles {
+        handle.join().unwrap();
     }
 
     let _ = server.shutdown().wait();

--- a/point_viewer_grpc/src/bin/octree_server.rs
+++ b/point_viewer_grpc/src/bin/octree_server.rs
@@ -19,7 +19,7 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::{io, thread};
 
-use point_viewer_grpc::service::start_grpc_server;
+use point_viewer_grpc::service::{start_grpc_server, GrpcOptions};
 
 fn main() {
     let matches = clap::App::new("octree_server")
@@ -37,7 +37,7 @@ fn main() {
 
     let port = value_t!(matches, "port", u16).unwrap_or(50051);
     let octree_directory = PathBuf::from(matches.value_of("octree_directory").unwrap());
-    let mut server = start_grpc_server(&octree_directory, "0.0.0.0", port);
+    let mut server = start_grpc_server(&octree_directory, "0.0.0.0", port, &GrpcOptions::default());
     server.start();
 
     for &(ref host, port) in server.bind_addrs() {

--- a/point_viewer_grpc/src/bin/octree_server.rs
+++ b/point_viewer_grpc/src/bin/octree_server.rs
@@ -41,7 +41,7 @@ fn main() {
 
     let port = value_t!(matches, "port", u16).unwrap_or(50051);
     let octree_directory = PathBuf::from(matches.value_of("octree_directory").unwrap());
-    let mut server = start_grpc_server(octree_directory, "0.0.0.0", port);
+    let mut server = start_grpc_server(octree_directory, "0.0.0.0", port, 1, 1);
     server.start();
 
     for &(ref host, port) in server.bind_addrs() {

--- a/point_viewer_grpc/src/bin/octree_server.rs
+++ b/point_viewer_grpc/src/bin/octree_server.rs
@@ -41,7 +41,7 @@ fn main() {
 
     let port = value_t!(matches, "port", u16).unwrap_or(50051);
     let octree_directory = PathBuf::from(matches.value_of("octree_directory").unwrap());
-    let mut server = start_grpc_server(octree_directory, "0.0.0.0", port, 1, 1);
+    let mut server = start_grpc_server(octree_directory, "0.0.0.0", port, 10, 3);
     server.start();
 
     for &(ref host, port) in server.bind_addrs() {

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -135,7 +135,7 @@ fn stream_points_back_to_sink(
                 OctreeQuery::FullPointcloudQuery(idx, total) => octree.all_points(idx, total).for_each(func),
             };
         }
-        tx.send((reply, WriteFlags::default())).unwrap_or(println!("Request was cancelled."));
+        tx.send((reply, WriteFlags::default())).unwrap_or_else(|_| println!("Request was cancelled."));
     });
 
     let rx = rx.map_err(|_| grpcio::Error::RemoteStopped);

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -118,8 +118,7 @@ fn stream_points_back_to_sink(
 
                 reply_size += bytes_per_point;
                 if reply_size > max_message_size - bytes_per_point {
-                    tx.send((reply.clone(), WriteFlags::default()))
-                        .unwrap_or(());
+                    tx.send((reply.clone(), WriteFlags::default())).unwrap();
                     reply.mut_positions().clear();
                     reply.mut_colors().clear();
                     reply.mut_intensities().clear();
@@ -138,8 +137,7 @@ fn stream_points_back_to_sink(
                 }
             };
         }
-        tx.send((reply, WriteFlags::default()))
-            .unwrap_or_else(|_| println!("Request was cancelled."));
+        tx.send((reply, WriteFlags::default())).unwrap();
     });
 
     let rx = rx.map_err(|_| grpcio::Error::RemoteStopped);
@@ -147,7 +145,7 @@ fn stream_points_back_to_sink(
         .send_all(rx)
         .map(|_| {})
         .map_err(|e| println!("failed to reply: {:?}", e));
-    ctx.spawn(f);
+    ctx.spawn(f)
 }
 
 impl proto_grpc::Octree for OctreeService {

--- a/point_viewer_grpc_proto_rust/src/proto.proto
+++ b/point_viewer_grpc_proto_rust/src/proto.proto
@@ -29,6 +29,8 @@ service Octree {
       returns (stream PointsReply);
   rpc GetAllPoints(GetAllPointsRequest)
       returns (stream PointsReply);
+  rpc GetAllPointsParallel(GetAllPointsParallelRequest)
+      returns (stream PointsReply);
 }
 
 message GetMetaRequest {
@@ -73,6 +75,11 @@ message GetPointsInFrustumRequest {
 }
 
 message GetAllPointsRequest {
+}
+
+message GetAllPointsParallelRequest {
+  int32 reqIndex = 1;
+  int32 total = 2;
 }
 
 message PointsReply {

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -171,7 +171,7 @@ impl<'a> InternalIterator for AllPointsIterator<'a> {
         let mut open_list = vec![NodeId::from_level_index(0, 0)];
         while !open_list.is_empty() {
             let current = open_list.pop().unwrap();
-            if current.index() as i32 % self.total == self.idx {
+            if current.index() % self.total as usize == self.idx as usize {
                 let iterator = NodeIterator::from_data_provider(
                     &*self.octree.data_provider,
                     &self.octree.meta,


### PR DESCRIPTION
This is an effort to parallelize the octree server.
* I printed the thread id in stream_points_back_to_sink() while making several parallel requests. Interestingly, it was always the same (grpc_cq_poll_0 or something similar), but when I set cq_count to > 1 and requests_slot_per_cq to 1, more threads appeared and performance improved.
* For the case of the full point cloud query, I implemented a helper method to only fetch a certain fraction of the octree. It can then be called for all of these fractions in parallel.
* I did a grid search for 16 parallel threads and found the optimum speedup in the full benchmark to be at values of 8-10 for cq_count and 2-3 for the requests_slot_per_cq parameter.
* The optimum speedup for the full benchmark is still only around 4x for 16 threads, but much higher for the grpc-less benchmark (server_benchmark).
* I appreciate discussion on how to best use grpc for best parallel performance. For instance, we're using the RpcContext's spawn method (https://docs.rs/grpcio/0.4.1/grpcio/struct.RpcContext.html) – is there heavy work in this future? Maybe someone experienced could offer comments on how this part of the code and gRPC work exactly.