### PR TITLE
Remove obsolete rustfmt options.

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,1 @@
-reorder_extern_crates=true
-reorder_imported_names=true
 reorder_imports=true


### PR DESCRIPTION
Running `cargo fmt --all` gave lots of
```
Warning: Unknown configuration option `reorder_extern_crates`
Warning: Unknown configuration option `reorder_imported_names`
```
This PR removes these warnings.