### PR TITLE
Initialize bbox with first element

### DIFF
--- a/src/generation.rs
+++ b/src/generation.rs
@@ -260,6 +260,10 @@ fn find_bounding_box(input: &InputFile) -> Aabb3<f32> {
     }
 
     stream.for_each(|p: &Point| {
+        if num_points == 0 {
+            let p3 = Point3::from_vec(p.position);
+            bounding_box = Aabb3::new(p3, p3);
+        }
         bounding_box = bounding_box.grow(Point3::from_vec(p.position));
         num_points += 1;
         if num_points % UPDATE_COUNT == 0 {


### PR DESCRIPTION
The bounding box is wrong for point clouds that don't contain (0, 0, 0). This solution may result in a small performance hit. Should I add a TODO to add a next() method to the stream? Then we can get the first point to initialize the bbox from that without adding a check inside the loop.