### PR TITLE
Make xrays upgradable from previous version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,6 +2875,7 @@ dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "streaming-stats 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoded 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xray_proto_rust 0.1.0",
 ]

--- a/xray/Cargo.toml
+++ b/xray/Cargo.toml
@@ -18,6 +18,7 @@ scoped-pool = "^0.1"
 serde = "1.0.9"
 serde_json = "1.0.9"
 serde_derive = "1.0.9"
+structopt = "0.2"
 urlencoded = "^0.3.0"
 streaming-stats = "0.2.2"
 

--- a/xray/src/bin/upgrade_xray_quadtree.rs
+++ b/xray/src/bin/upgrade_xray_quadtree.rs
@@ -1,0 +1,68 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use protobuf::Message;
+use std::fs::File;
+use std::io::{BufWriter, Cursor};
+use std::path::{Path, PathBuf};
+use structopt::StructOpt;
+use xray_proto_rust::proto;
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "upgrade_xray_quadtree")]
+struct CommandlineArguments {
+    /// Directory of xray quadtree to upgrade.
+    #[structopt(parse(from_os_str))]
+    directory: PathBuf,
+}
+
+fn upgrade_version2(filename: &Path, mut meta: proto::Meta) {
+    println!("Upgrading version 2 => 3.");
+    let bounding_rect = meta.mut_bounding_rect();
+    let deprecated_min = bounding_rect.get_deprecated_min();
+    let mut min = proto::Vector2d::new();
+    min.set_x(f64::from(deprecated_min.x));
+    min.set_y(f64::from(deprecated_min.y));
+    bounding_rect.set_min(min);
+    bounding_rect.deprecated_min.clear();
+    bounding_rect.set_edge_length(f64::from(bounding_rect.get_deprecated_edge_length()));
+
+    meta.version = 3;
+    let mut buf_writer = BufWriter::new(File::create(filename).unwrap());
+    meta.write_to_writer(&mut buf_writer).unwrap();
+}
+
+fn main() {
+    let args = CommandlineArguments::from_args();
+    let filename = args.directory.join("meta.pb");
+
+    loop {
+        let meta = {
+            let data = std::fs::read(&filename).unwrap();
+            protobuf::parse_from_reader::<proto::Meta>(&mut Cursor::new(data))
+                .expect("Could not read meta proto")
+        };
+        match meta.version {
+            2 => upgrade_version2(&filename, meta),
+            other if other == xray::CURRENT_VERSION => {
+                println!("Xray quadtree at current version {}", xray::CURRENT_VERSION);
+                break;
+            }
+            other => {
+                println!("Do not know how to upgrade version {}", other);
+                std::process::exit(1);
+            }
+        }
+    }
+}

--- a/xray/src/lib.rs
+++ b/xray/src/lib.rs
@@ -8,6 +8,8 @@ use serde_derive::Serialize;
 use std::io::{self, Cursor};
 use std::path::Path;
 
+// Version 2 -> 3: Change in Rect proto from Vector2f to Vector2d min and float to double edge_length.
+// We are able to convert the proto on read, so the tools can still read version 2.
 pub const CURRENT_VERSION: i32 = 3;
 
 #[derive(Debug, Clone)]
@@ -44,26 +46,37 @@ impl Meta {
 
     // Reads the meta from the provided encoded protobuf.
     pub fn from_proto(proto: &proto::Meta) -> Self {
-        if proto.version != CURRENT_VERSION {
-            panic!(
+        match proto.version {
+            2 => println!(
+                "Data is an older xray quadtree version: {}, current would be {}. \
+                 If feasible, try upgrading this xray quadtree using `upgrade_xray_quadtree`.",
+                proto.version, CURRENT_VERSION
+            ),
+            CURRENT_VERSION => (),
+            _ => panic!(
                 "Invalid version. We only support {}, but found {}.",
                 CURRENT_VERSION, proto.version
-            );
+            ),
         }
 
+        let bounding_rect = proto.get_bounding_rect();
+        let (min, edge_length) = bounding_rect.min.clone().into_option().map_or_else(
+            || {
+                let deprecated_min = bounding_rect.deprecated_min.clone().unwrap();
+                (
+                    Point2::new(f64::from(deprecated_min.x), f64::from(deprecated_min.y)),
+                    f64::from(bounding_rect.get_deprecated_edge_length()),
+                )
+            },
+            |v| (Point2::new(v.x, v.y), bounding_rect.get_edge_length()),
+        );
         Meta {
             nodes: proto
                 .nodes
                 .iter()
                 .map(|n| NodeId::new(n.level as u8, n.index))
                 .collect(),
-            bounding_rect: Rect::new(
-                Point2::new(
-                    proto.get_bounding_rect().get_min().x,
-                    proto.get_bounding_rect().get_min().y,
-                ),
-                proto.get_bounding_rect().get_edge_length(),
-            ),
+            bounding_rect: Rect::new(min, edge_length),
             tile_size: proto.tile_size,
             deepest_level: proto.deepest_level as u8,
         }

--- a/xray/src/lib.rs
+++ b/xray/src/lib.rs
@@ -62,7 +62,7 @@ impl Meta {
         let bounding_rect = proto.get_bounding_rect();
         let (min, edge_length) = bounding_rect.min.clone().into_option().map_or_else(
             || {
-                let deprecated_min = bounding_rect.deprecated_min.clone().unwrap();
+                let deprecated_min = bounding_rect.get_deprecated_min();
                 (
                     Point2::new(f64::from(deprecated_min.x), f64::from(deprecated_min.y)),
                     f64::from(bounding_rect.get_deprecated_edge_length()),

--- a/xray_proto_rust/src/proto.proto
+++ b/xray_proto_rust/src/proto.proto
@@ -31,6 +31,11 @@ message Vector2d {
 message Rect {
   Vector2d min = 3;
   double edge_length = 4;
+
+  // These were used in VERSION <= 2. Once we no longer need to keep these
+  // working, we should remove these entries.
+  Vector2f deprecated_min = 1;
+  float deprecated_edge_length = 2;
 }
 
 message NodeId {


### PR DESCRIPTION
PR #232 didn't take xray quadtree compatibility and upgrades into account.