### PR TITLE
Input arguments for points_viewer

### DIFF
--- a/octree_web_viewer/src/bin/points_web_viewer.rs
+++ b/octree_web_viewer/src/bin/points_web_viewer.rs
@@ -29,7 +29,6 @@ use structopt::StructOpt;
 #[structopt(name = "points_web_viewer", about = "Visualizing points")]
 pub struct CommandLineArguments {
     /// The octree directory to serve, including a trailing slash.
-    /// this overrides <--prefix> and <--octree_id> options
     #[structopt(name = "DIR", parse(from_os_str))]
     octree_path: PathBuf,
     /// Port to listen on.

--- a/octree_web_viewer/src/bin/points_web_viewer.rs
+++ b/octree_web_viewer/src/bin/points_web_viewer.rs
@@ -58,7 +58,7 @@ pub fn state_from(args: CommandLineArguments) -> Result<AppState, PointsViewerEr
         let mut octree_directory = args.octree_path.parent().unwrap_or_else(|| Path::new(""));
         while suffix_depth > 1 {
             octree_directory = octree_directory.parent().unwrap_or_else(|| Path::new(""));
-            suffix_depth = suffix_depth - 1;
+            suffix_depth -= 1;
         }
         suffix = args.octree_path.strip_prefix(&octree_directory)?;
         octree_path = PathBuf::from(octree_directory);

--- a/octree_web_viewer/src/bin/points_web_viewer.rs
+++ b/octree_web_viewer/src/bin/points_web_viewer.rs
@@ -18,7 +18,6 @@ use octree_web_viewer::utils::start_octree_server;
 use point_viewer::octree::OctreeFactory;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use structopt::clap::ArgGroup;
 use structopt::StructOpt;
 
 /// HTTP web viewer for 3d points stored in OnDiskOctrees
@@ -50,7 +49,7 @@ pub struct CommandLineArguments {
 /// init app state with command arguments
 /// backward compatibilty is ensured
 pub fn state_from(args: CommandLineArguments) -> Result<AppState, PointsViewerError> {
-    let octee_factory = OctreeFactory::new();
+    let octree_factory = OctreeFactory::new();
     let mut suffix = Path::new("");
     let mut suffix_depth = args.suffix_depth;
     let mut octree_path: PathBuf;
@@ -74,7 +73,7 @@ pub fn state_from(args: CommandLineArguments) -> Result<AppState, PointsViewerEr
         prefix,
         suffix,
         octree_id.to_str().unwrap(),
-        octee_factory,
+        octree_factory,
     ))
 }
 

--- a/octree_web_viewer/src/bin/points_web_viewer.rs
+++ b/octree_web_viewer/src/bin/points_web_viewer.rs
@@ -49,23 +49,15 @@ pub struct CommandLineArguments {
 /// backward compatibilty is ensured
 pub fn state_from(args: CommandLineArguments) -> Result<AppState, PointsViewerError> {
     let octree_factory = OctreeFactory::new();
-    let mut suffix = Path::new("");
-    let mut suffix_depth = args.suffix_depth;
+    let mut octree_prefix_id = args.octree_path.as_path();
     // get octree path without suffix
-    let octree_path = if suffix_depth > 0 {
-        let mut octree_directory = args.octree_path.parent().unwrap_or_else(|| Path::new(""));
-        while suffix_depth > 1 {
-            octree_directory = octree_directory.parent().unwrap_or_else(|| Path::new(""));
-            suffix_depth -= 1;
-        }
-        suffix = args.octree_path.strip_prefix(&octree_directory)?;
-        PathBuf::from(octree_directory)
-    } else {
-        args.octree_path
-    };
+    for _ in 0..args.suffix_depth {
+        octree_prefix_id = args.octree_path.parent().unwrap_or_else(|| Path::new(""));
+    }
 
-    let prefix = octree_path.parent().unwrap_or_else(|| Path::new(""));
-    let octree_id = octree_path.strip_prefix(&prefix)?;
+    let suffix = args.octree_path.strip_prefix(&octree_prefix_id)?;
+    let prefix = octree_prefix_id.parent().unwrap_or_else(|| Path::new(""));
+    let octree_id = octree_prefix_id.strip_prefix(&prefix)?;
     Ok(AppState::new(
         args.cache_max,
         prefix,

--- a/octree_web_viewer/src/bin/points_web_viewer.rs
+++ b/octree_web_viewer/src/bin/points_web_viewer.rs
@@ -52,19 +52,18 @@ pub fn state_from(args: CommandLineArguments) -> Result<AppState, PointsViewerEr
     let octree_factory = OctreeFactory::new();
     let mut suffix = Path::new("");
     let mut suffix_depth = args.suffix_depth;
-    let mut octree_path: PathBuf;
-    // parse path if suffix is specified
-    if suffix_depth > 0 {
+    // get octree path without suffix
+    let octree_path = if suffix_depth > 0 {
         let mut octree_directory = args.octree_path.parent().unwrap_or_else(|| Path::new(""));
         while suffix_depth > 1 {
             octree_directory = octree_directory.parent().unwrap_or_else(|| Path::new(""));
             suffix_depth -= 1;
         }
         suffix = args.octree_path.strip_prefix(&octree_directory)?;
-        octree_path = PathBuf::from(octree_directory);
+        PathBuf::from(octree_directory)
     } else {
-        octree_path = args.octree_path;
-    }
+        args.octree_path
+    };
 
     let prefix = octree_path.parent().unwrap_or_else(|| Path::new(""));
     let octree_id = octree_path.strip_prefix(&prefix)?;


### PR DESCRIPTION
Here I tried to streamline how will a user launch the program.
Backward compatibility: no options: the path will be taken as is 

Serving multiple trees with common structure (ancestor and subfolder) is done by specifying the depth  of the subfolder structure. By default is such depth 0.
For example run
./target/points_viewer <common_path>/octree_id/<subfolder_structure> --suffix_depth =2
if depth =2 i expect <subfolder_structure> = subfolder1/subfolder2 
In subfolder 2 reside the files of the octree. by changing the identifier in the GUI another octree with
<common_path>/another_octree_id/subfolder1/subfolder2 can be displayed in the browser

Advantage: reducing the number and length of the inputs
