### PR TITLE
Fixed bounding box

### DIFF
--- a/src/bin/build_octree.rs
+++ b/src/bin/build_octree.rs
@@ -30,7 +30,7 @@ struct CommandlineArguments {
     #[structopt(long = "resolution", default_value = "0.001")]
     resolution: f64,
     // Flag to skip bbox calculation and use a fixed bbox.
-    // The fixed bbox is extends 1048576 length units in each direction.
+    // The fixed bbox is extends 6400000 length units in each direction.
     #[structopt(long = "bbox_type", raw(possible_values = "&RootBbox::variants()", case_insensitive = "true"), default_value = "FromData")]
     bbox_type: RootBbox,
 }

--- a/src/bin/build_octree.rs
+++ b/src/bin/build_octree.rs
@@ -31,12 +31,22 @@ struct CommandlineArguments {
     resolution: f64,
     // Flag to skip bbox calculation and use a fixed bbox.
     // The fixed bbox is extends 6400000 length units in each direction.
-    #[structopt(long = "bbox_type", raw(possible_values = "&RootBbox::variants()", case_insensitive = "true"), default_value = "FromData")]
+    #[structopt(
+        long = "bbox_type",
+        raw(possible_values = "&RootBbox::variants()", case_insensitive = "true"),
+        default_value = "FromData"
+    )]
     bbox_type: RootBbox,
 }
 
 fn main() {
     let args = CommandlineArguments::from_args();
     let pool = scoped_pool::Pool::new(10);
-    build_octree_from_file(&pool, args.output_directory, args.resolution, args.input, args.bbox_type);
+    build_octree_from_file(
+        &pool,
+        args.output_directory,
+        args.resolution,
+        args.input,
+        args.bbox_type,
+    );
 }

--- a/src/bin/build_octree.rs
+++ b/src/bin/build_octree.rs
@@ -31,17 +31,12 @@ struct CommandlineArguments {
     resolution: f64,
     // Flag to skip bbox calculation and use a fixed bbox.
     // The fixed bbox is extends 1048576 length units in each direction.
-    #[structopt(long = "fixed_bbox")]
-    fixed_bbox: bool,
+    #[structopt(long = "bbox_type", raw(possible_values = "&RootBbox::variants()", case_insensitive = "true"), default_value = "FromData")]
+    bbox_type: RootBbox,
 }
 
 fn main() {
     let args = CommandlineArguments::from_args();
     let pool = scoped_pool::Pool::new(10);
-    let bbox_type = if args.fixed_bbox {
-        RootBbox::EarthECEF()
-    } else {
-        RootBbox::FromData()
-    };
-    build_octree_from_file(&pool, args.output_directory, args.resolution, args.input, bbox_type);
+    build_octree_from_file(&pool, args.output_directory, args.resolution, args.input, args.bbox_type);
 }

--- a/src/bin/build_octree.rs
+++ b/src/bin/build_octree.rs
@@ -30,7 +30,9 @@ struct CommandlineArguments {
     #[structopt(long = "resolution", default_value = "0.001")]
     resolution: f64,
     // Flag to skip bbox calculation and use a fixed bbox.
-    // The fixed bbox is extends 6400000 length units in each direction.
+    // The fixed bbox is zero-centered and extends 6_400_000 length units in
+    // each direction, so that the octree can cover the whole earth when
+    // using ECEF coordinates.
     #[structopt(
         long = "bbox_type",
         raw(possible_values = "&RootBbox::variants()", case_insensitive = "true"),

--- a/src/bin/build_octree.rs
+++ b/src/bin/build_octree.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use point_viewer::generation::build_octree_from_file;
+use point_viewer::generation::{build_octree_from_file, RootBbox};
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -29,10 +29,19 @@ struct CommandlineArguments {
     /// This decides on the number of bits used to encode each node.
     #[structopt(long = "resolution", default_value = "0.001")]
     resolution: f64,
+    // Flag to skip bbox calculation and use a fixed bbox.
+    // The fixed bbox is extends 1048576 length units in each direction.
+    #[structopt(long = "fixed_bbox")]
+    fixed_bbox: bool,
 }
 
 fn main() {
     let args = CommandlineArguments::from_args();
     let pool = scoped_pool::Pool::new(10);
-    build_octree_from_file(&pool, args.output_directory, args.resolution, args.input);
+    let bbox_type = if args.fixed_bbox {
+        RootBbox::EarthECEF()
+    } else {
+        RootBbox::FromData()
+    };
+    build_octree_from_file(&pool, args.output_directory, args.resolution, args.input, bbox_type);
 }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -305,7 +305,10 @@ pub fn build_octree_from_file(
         }
     };
     let bounding_box = match bbox_type {
-        RootBbox::EarthECEF => { let p = Point3::new(6400000.0, 6400000.0, 6400000.0); Aabb3::new(-1.0 * p, p) },
+        RootBbox::EarthECEF => {
+            let p = Point3::new(6_400_000.0, 6_400_000.0, 6_400_000.0);
+            Aabb3::new(-1.0 * p, p)
+        }
         RootBbox::FromData => find_bounding_box(&input),
     };
     let (stream, _) = make_stream(&input);

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -30,6 +30,7 @@ use std::fs::{self, File};
 use std::io::{BufWriter, Stdout};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
+use structopt::clap::{_clap_count_exprs, arg_enum};
 
 const UPDATE_COUNT: i64 = 100_000;
 const MAX_POINTS_PER_NODE: i64 = 100_000;
@@ -250,10 +251,13 @@ fn make_stream(input: &InputFile) -> (InputFileIterator, Option<ProgressBar<Stdo
     (stream, progress_bar)
 }
 
-pub enum RootBbox {
-    FromData(),
-    EarthECEF(),
-    // TODO(nnmm): Custom fixed bbox
+arg_enum! {
+    #[derive(Debug)]
+    pub enum RootBbox {
+        FromData,
+        EarthECEF,
+        // TODO(nnmm): Custom fixed bbox
+    }
 }
 /// Returns the bounding box containing all points
 fn find_bounding_box(input: &InputFile) -> Aabb3<f64> {
@@ -301,8 +305,8 @@ pub fn build_octree_from_file(
         }
     };
     let bounding_box = match bbox_type {
-        RootBbox::EarthECEF() => { let p = Point3::new(1048576.0, 1048576.0, 1048576.0); Aabb3::new(-1.0 * p, p) },
-        RootBbox::FromData() => find_bounding_box(&input),
+        RootBbox::EarthECEF => { let p = Point3::new(6400000.0, 6400000.0, 6400000.0); Aabb3::new(-1.0 * p, p) },
+        RootBbox::FromData => find_bounding_box(&input),
     };
     let (stream, _) = make_stream(&input);
     build_octree(pool, output_directory, resolution, bounding_box, stream)


### PR DESCRIPTION
* Allow choosing a fixed bbox that encompasses the earth instead of determining the box from data
* The bbox dimensions were set to a number of meters such that the earth can fit in the bounding box