### PR TITLE
Fix for subsampling resulting in empty nodes

### DIFF
--- a/src/generation.rs
+++ b/src/generation.rs
@@ -394,9 +394,7 @@ pub fn build_octree(
         pool.scoped(|scope| {
             scope.execute(|| {
                 for (id, num_points) in finished_nodes_receiver {
-                    if num_points > 0 {
-                        finished_nodes.insert(id, num_points);
-                    }
+                    finished_nodes.insert(id, num_points);
                 }
             });
 

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -479,7 +479,7 @@ fn maybe_push_node(
     node: Node,
     projection_matrix: &Matrix4<f32>,
 ) {
-    if !nodes.contains_key(&node.id) {
+    if nodes.get(&node.id).map_or(0, |meta| meta.num_points) == 0 {
         return;
     }
     let size_on_screen = relative_size_on_screen(&node.bounding_cube, projection_matrix);

--- a/src/octree/node_iterator.rs
+++ b/src/octree/node_iterator.rs
@@ -12,11 +12,16 @@ use num_traits::identities::Zero;
 use std::io::{BufReader, Read};
 
 /// Streams points from our data provider representation.
-pub struct NodeIterator {
+pub struct NodeIteratorWithData {
     xyz_reader: BufReader<Box<dyn Read>>,
     rgb_reader: BufReader<Box<dyn Read>>,
     intensity_reader: Option<BufReader<Box<dyn Read>>>,
     meta: NodeMeta,
+}
+
+pub enum NodeIterator {
+    WithData(NodeIteratorWithData),
+    Empty,
 }
 
 impl NodeIterator {
@@ -26,6 +31,9 @@ impl NodeIterator {
         id: &NodeId,
         num_points: i64,
     ) -> Result<Self> {
+        if num_points == 0 {
+            return Ok(NodeIterator::Empty);
+        }
         let bounding_cube = id.find_bounding_cube(&Cube::bounding(&octree_meta.bounding_box));
         let position_encoding = PositionEncoding::new(&bounding_cube, octree_meta.resolution);
         let intensity_reader = match octree_data_provider.data(id, vec![NodeLayer::Intensity]) {
@@ -40,7 +48,7 @@ impl NodeIterator {
 
         let mut position_color_reads =
             octree_data_provider.data(id, vec![NodeLayer::Position, NodeLayer::Color])?;
-        Ok(NodeIterator {
+        let iter = NodeIteratorWithData {
             xyz_reader: BufReader::new(
                 position_color_reads
                     .remove(&NodeLayer::Position)
@@ -57,94 +65,102 @@ impl NodeIterator {
                 position_encoding,
                 num_points,
             },
-        })
+        };
+        Ok(NodeIterator::WithData(iter))
     }
 }
 
 impl InternalIterator for NodeIterator {
     fn size_hint(&self) -> Option<usize> {
-        Some(self.meta.num_points as usize)
+        match self {
+            NodeIterator::WithData(ref iter) => Some(iter.meta.num_points as usize),
+            NodeIterator::Empty => Some(0),
+        }
     }
+    fn for_each<F: FnMut(&Point)>(self, mut f: F) {
+        let mut iter = match self {
+            NodeIterator::WithData(iter) => iter,
+            NodeIterator::Empty => return,
+        };
 
-    fn for_each<F: FnMut(&Point)>(mut self, mut f: F) {
         let mut point = Point {
             position: Vector3::zero(),
             color: color::RED.to_u8(), // is overwritten
             intensity: None,
         };
 
-        let edge_length = self.meta.bounding_cube.edge_length();
-        let min = self.meta.bounding_cube.min();
-        for _ in 0..self.meta.num_points {
+        let edge_length = iter.meta.bounding_cube.edge_length();
+        let min = iter.meta.bounding_cube.min();
+        for _ in 0..iter.meta.num_points {
             // I tried pulling out this match by taking a function pointer to a 'decode_position'
             // function. This replaces a branch per point vs a function call per point and turned
             // out to be marginally slower.
-            match self.meta.position_encoding {
+            match iter.meta.position_encoding {
                 PositionEncoding::Float32 => {
                     point.position.x = decode(
-                        self.xyz_reader.read_f32::<LittleEndian>().unwrap(),
+                        iter.xyz_reader.read_f32::<LittleEndian>().unwrap(),
                         min.x,
                         edge_length,
                     );
                     point.position.y = decode(
-                        self.xyz_reader.read_f32::<LittleEndian>().unwrap(),
+                        iter.xyz_reader.read_f32::<LittleEndian>().unwrap(),
                         min.y,
                         edge_length,
                     );
                     point.position.z = decode(
-                        self.xyz_reader.read_f32::<LittleEndian>().unwrap(),
+                        iter.xyz_reader.read_f32::<LittleEndian>().unwrap(),
                         min.z,
                         edge_length,
                     );
                 }
                 PositionEncoding::Float64 => {
                     point.position.x = decode(
-                        self.xyz_reader.read_f64::<LittleEndian>().unwrap(),
+                        iter.xyz_reader.read_f64::<LittleEndian>().unwrap(),
                         min.x,
                         edge_length,
                     );
                     point.position.y = decode(
-                        self.xyz_reader.read_f64::<LittleEndian>().unwrap(),
+                        iter.xyz_reader.read_f64::<LittleEndian>().unwrap(),
                         min.y,
                         edge_length,
                     );
                     point.position.z = decode(
-                        self.xyz_reader.read_f64::<LittleEndian>().unwrap(),
+                        iter.xyz_reader.read_f64::<LittleEndian>().unwrap(),
                         min.z,
                         edge_length,
                     );
                 }
                 PositionEncoding::Uint8 => {
                     point.position.x =
-                        fixpoint_decode(self.xyz_reader.read_u8().unwrap(), min.x, edge_length);
+                        fixpoint_decode(iter.xyz_reader.read_u8().unwrap(), min.x, edge_length);
                     point.position.y =
-                        fixpoint_decode(self.xyz_reader.read_u8().unwrap(), min.y, edge_length);
+                        fixpoint_decode(iter.xyz_reader.read_u8().unwrap(), min.y, edge_length);
                     point.position.z =
-                        fixpoint_decode(self.xyz_reader.read_u8().unwrap(), min.z, edge_length);
+                        fixpoint_decode(iter.xyz_reader.read_u8().unwrap(), min.z, edge_length);
                 }
                 PositionEncoding::Uint16 => {
                     point.position.x = fixpoint_decode(
-                        self.xyz_reader.read_u16::<LittleEndian>().unwrap(),
+                        iter.xyz_reader.read_u16::<LittleEndian>().unwrap(),
                         min.x,
                         edge_length,
                     );
                     point.position.y = fixpoint_decode(
-                        self.xyz_reader.read_u16::<LittleEndian>().unwrap(),
+                        iter.xyz_reader.read_u16::<LittleEndian>().unwrap(),
                         min.y,
                         edge_length,
                     );
                     point.position.z = fixpoint_decode(
-                        self.xyz_reader.read_u16::<LittleEndian>().unwrap(),
+                        iter.xyz_reader.read_u16::<LittleEndian>().unwrap(),
                         min.z,
                         edge_length,
                     );
                 }
             }
 
-            point.color.red = self.rgb_reader.read_u8().unwrap();
-            point.color.green = self.rgb_reader.read_u8().unwrap();
-            point.color.blue = self.rgb_reader.read_u8().unwrap();
-            if let Some(ir) = self.intensity_reader.as_mut() {
+            point.color.red = iter.rgb_reader.read_u8().unwrap();
+            point.color.green = iter.rgb_reader.read_u8().unwrap();
+            point.color.blue = iter.rgb_reader.read_u8().unwrap();
+            if let Some(ir) = iter.intensity_reader.as_mut() {
                 point.intensity = Some(ir.read_f32::<LittleEndian>().unwrap());
             }
             f(&point);

--- a/src/octree/node_writer.rs
+++ b/src/octree/node_writer.rs
@@ -18,6 +18,18 @@ pub struct NodeWriter {
     num_written: i64,
 }
 
+impl Drop for NodeWriter {
+    fn drop(&mut self) {
+        // If we did not write anything into this node, it should not exist.
+        if self.num_written == 0 {
+            self.remove_all_files();
+        }
+
+        // TODO(hrapp): Add some sanity checks that we do not have nodes with ridiculously low
+        // amount of points laying around?
+    }
+}
+
 impl NodeWriter {
     pub fn new(
         octree_data_provider: &OnDiskOctreeDataProvider,
@@ -118,5 +130,12 @@ impl NodeWriter {
 
     pub fn num_written(&self) -> i64 {
         self.num_written
+    }
+
+    fn remove_all_files(&self) {
+        // We are ignoring deletion errors here in case the file is already gone.
+        let _ = fs::remove_file(&self.stem.with_extension(NodeLayer::Position.extension()));
+        let _ = fs::remove_file(&self.stem.with_extension(NodeLayer::Color.extension()));
+        let _ = fs::remove_file(&self.stem.with_extension(NodeLayer::Intensity.extension()));
     }
 }

--- a/src/octree/node_writer.rs
+++ b/src/octree/node_writer.rs
@@ -18,18 +18,6 @@ pub struct NodeWriter {
     num_written: i64,
 }
 
-impl Drop for NodeWriter {
-    fn drop(&mut self) {
-        // If we did not write anything into this node, it should not exist.
-        if self.num_written == 0 {
-            self.remove_all_files();
-        }
-
-        // TODO(hrapp): Add some sanity checks that we do not have nodes with ridiculously low
-        // amount of points laying around?
-    }
-}
-
 impl NodeWriter {
     pub fn new(
         octree_data_provider: &OnDiskOctreeDataProvider,
@@ -130,11 +118,5 @@ impl NodeWriter {
 
     pub fn num_written(&self) -> i64 {
         self.num_written
-    }
-
-    fn remove_all_files(&self) {
-        // We are ignoring deletion errors here in case the file is already gone.
-        let _ = fs::remove_file(&self.stem.with_extension(NodeLayer::Position.extension()));
-        let _ = fs::remove_file(&self.stem.with_extension(NodeLayer::Color.extension()));
     }
 }


### PR DESCRIPTION
Subsampling would sometimes result in empty nodes, when there is a long chain of nodes with only one child, as you'd get with big bounding boxes. However, octree queries work by recursing into the octree, starting from the root node, and take nonexistence as an indication that no nodes exist below that points.