### PR TITLE
Change to f64 projection matrix.

### DIFF
--- a/octree_web_viewer/src/backend.rs
+++ b/octree_web_viewer/src/backend.rs
@@ -25,10 +25,10 @@ pub fn get_visible_nodes(
         Ok(octree) => {
             let matrix = {
                 // Entries are column major.
-                let e: Vec<f32> = matrix_query
+                let e: Vec<f64> = matrix_query
                     .matrix
                     .split(',')
-                    .map(|s| s.parse::<f32>().unwrap())
+                    .map(|s| s.parse::<f64>().unwrap())
                     .collect();
                 // matrix size check
                 if 16 == e.len() {

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -45,7 +45,7 @@ struct OctreeService {
 
 #[derive(Debug)]
 enum OctreeQuery {
-    Frustum(Matrix4<f32>),
+    Frustum(Matrix4<f64>),
     Box(Aabb3<f64>),
     FullPointcloud,
 }
@@ -120,10 +120,10 @@ impl proto_grpc::Octree for OctreeService {
         resp: ServerStreamingSink<proto::PointsReply>,
     ) {
         let projection_matrix = Matrix4::from(PerspectiveFov {
-            fovy: Rad(req.fovy_rad as f32),
-            aspect: (req.aspect as f32),
-            near: (req.z_near as f32),
-            far: (req.z_far as f32),
+            fovy: Rad(req.fovy_rad),
+            aspect: req.aspect,
+            near: req.z_near,
+            far: req.z_far,
         });
         let rotation = {
             let q = req.rotation.unwrap();

--- a/point_viewer_grpc_proto_rust/src/proto.proto
+++ b/point_viewer_grpc_proto_rust/src/proto.proto
@@ -75,9 +75,6 @@ message GetPointsInFrustumRequest {
   double z_far = 6;
 
   string octree_id = 7;
-
-  point_viewer.proto.Vector3f deprecated_translation = 1;
-  point_viewer.proto.Quaternionf deprecated_rotation = 2;
 }
 
 message GetAllPointsRequest {

--- a/point_viewer_grpc_proto_rust/src/proto.proto
+++ b/point_viewer_grpc_proto_rust/src/proto.proto
@@ -57,10 +57,10 @@ message GetPointsInBoxRequest {
 
 message GetPointsInFrustumRequest {
   // Vector defining the translation.
-  point_viewer.proto.Vector3f translation = 1;
+  point_viewer.proto.Vector3d translation = 8;
 
   // Unit quaternion specifying the rotation.
-  point_viewer.proto.Quaternionf rotation = 2;
+  point_viewer.proto.Quaterniond rotation = 9;
 
   // Field of view angle in radians.
   double fovy_rad = 3;
@@ -75,6 +75,9 @@ message GetPointsInFrustumRequest {
   double z_far = 6;
 
   string octree_id = 7;
+
+  point_viewer.proto.Vector3f deprecated_translation = 1;
+  point_viewer.proto.Quaternionf deprecated_rotation = 2;
 }
 
 message GetAllPointsRequest {

--- a/point_viewer_proto_rust/src/proto.proto
+++ b/point_viewer_proto_rust/src/proto.proto
@@ -37,6 +37,13 @@ message Quaternionf {
   float w = 4;
 }
 
+message Quaterniond {
+  double x = 1;
+  double y = 2;
+  double z = 3;
+  double w = 4;
+}
+
 // Based on OpenGL standards, the value of fields will be between 0 and 1
 message Color {
   float red = 1;

--- a/point_viewer_proto_rust/src/proto.proto
+++ b/point_viewer_proto_rust/src/proto.proto
@@ -30,13 +30,6 @@ message Vector3d {
   double z = 3;
 }
 
-message Quaternionf {
-  float x = 1;
-  float y = 2;
-  float z = 3;
-  float w = 4;
-}
-
 message Quaterniond {
   double x = 1;
   double y = 2;

--- a/sdl_viewer/shaders/box_drawer_outline.vs
+++ b/sdl_viewer/shaders/box_drawer_outline.vs
@@ -1,7 +1,7 @@
 #version 410 core
 
-layout(location = 0) in vec3 position;
+layout(location = 0) in dvec3 position;
 
-uniform mat4 transform;
+uniform dmat4 transform;
 
-void main() { gl_Position = transform * vec4(position, 1.0f); }
+void main() { gl_Position = vec4(transform * dvec4(position, 1.0lf)); }

--- a/sdl_viewer/src/bin/sdl_viewer.rs
+++ b/sdl_viewer/src/bin/sdl_viewer.rs
@@ -29,7 +29,7 @@ impl Extension for NullExtension {
         Self
     }
 
-    fn camera_changed(&mut self, _: &Matrix4<f32>) {}
+    fn camera_changed(&mut self, _: &Matrix4<f64>) {}
 
     fn draw(&mut self) {}
 }

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -60,14 +60,14 @@ struct PointCloudRenderer {
     // TODO(sirver): Logging does not fit into this classes responsibilities.
     last_log: time::PreciseTime,
     visible_nodes: Vec<octree::NodeId>,
-    get_visible_nodes_params_tx: mpsc::Sender<Matrix4<f32>>,
+    get_visible_nodes_params_tx: mpsc::Sender<Matrix4<f64>>,
     get_visible_nodes_result_rx: mpsc::Receiver<Vec<octree::NodeId>>,
     num_frames: u32,
     point_size: f32,
     gamma: f32,
     needs_drawing: bool,
     max_nodes_in_memory: usize,
-    world_to_gl: Matrix4<f32>,
+    world_to_gl: Matrix4<f64>,
     max_nodes_moving: usize,
     show_octree_nodes: bool,
     node_views: NodeViewContainer,
@@ -91,7 +91,7 @@ impl PointCloudRenderer {
         // calculation and sends the visible nodes back to the drawing thread. If multiple requests
         // queue up while it is processing one, it will drop all but the latest one before
         // restarting the next calculation.
-        let (get_visible_nodes_params_tx, rx) = mpsc::channel::<Matrix4<f32>>();
+        let (get_visible_nodes_params_tx, rx) = mpsc::channel::<Matrix4<f64>>();
         let (tx, get_visible_nodes_result_rx) = mpsc::channel();
         let octree_clone = octree.clone();
         thread::spawn(move || {
@@ -132,7 +132,7 @@ impl PointCloudRenderer {
         }
     }
 
-    pub fn camera_changed(&mut self, world_to_gl: &Matrix4<f32>) {
+    pub fn camera_changed(&mut self, world_to_gl: &Matrix4<f64>) {
         self.last_moving = time::PreciseTime::now();
         self.needs_drawing = true;
         self.node_drawer.update_world_to_gl(world_to_gl);
@@ -299,7 +299,7 @@ fn load_camera(index: usize, pose_path: &Option<PathBuf>, camera: &mut Camera) {
 pub trait Extension {
     fn pre_init<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b>;
     fn new(matches: &clap::ArgMatches, opengl: Rc<opengl::Gl>) -> Self;
-    fn camera_changed(&mut self, transform: &Matrix4<f32>);
+    fn camera_changed(&mut self, transform: &Matrix4<f64>);
     fn draw(&mut self);
 }
 
@@ -511,13 +511,13 @@ pub fn run<T: Extension>(octree_factory: OctreeFactory) {
         }
 
         if let Some(j) = joystick.as_ref() {
-            let x = f32::from(j.axis(0).unwrap()) / 500.;
-            let y = f32::from(-j.axis(1).unwrap()) / 500.;
-            let z = f32::from(-j.axis(2).unwrap()) / 500.;
-            let up = f32::from(j.axis(3).unwrap()) / 500.;
+            let x = f64::from(j.axis(0).unwrap()) / 500.;
+            let y = f64::from(-j.axis(1).unwrap()) / 500.;
+            let z = f64::from(-j.axis(2).unwrap()) / 500.;
+            let up = f64::from(j.axis(3).unwrap()) / 500.;
             // Combine tilting and turning on the knob.
             let around =
-                f32::from(j.axis(4).unwrap()) / 500. - f32::from(j.axis(5).unwrap()) / 500.;
+                f64::from(j.axis(4).unwrap()) / 500. - f64::from(j.axis(5).unwrap()) / 500.;
             camera.pan(x, y, z);
             camera.rotate(up, around);
         }

--- a/sdl_viewer/src/node_drawer.rs
+++ b/sdl_viewer/src/node_drawer.rs
@@ -105,14 +105,14 @@ impl NodeDrawer {
         }
     }
 
-    pub fn update_world_to_gl(&mut self, matrix: &Matrix4<f32>) {
+    pub fn update_world_to_gl(&mut self, matrix: &Matrix4<f64>) {
         let update_matrix = |node_program: &mut NodeProgram| unsafe {
             node_program.program.gl.UseProgram(node_program.program.id);
             node_program.program.gl.UniformMatrix4dv(
                 node_program.u_world_to_gl,
                 1,
                 false as GLboolean,
-                matrix.cast::<f64>().unwrap().as_ptr(),
+                matrix.as_ptr(),
             );
         };
         update_matrix(&mut self.program_f32);

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -81,8 +81,8 @@ pub fn to_meta_proto(octree_meta: &OctreeMeta, nodes: Vec<proto::Node>) -> proto
 
 // TODO(hrapp): something is funky here. "r" is smaller on screen than "r4" in many cases, though
 // that is impossible.
-fn project(m: &Matrix4<f32>, p: &Point3<f64>) -> Point3<f64> {
-    let q = m.cast::<f64>().unwrap() * Point3::to_homogeneous(*p);
+fn project(m: &Matrix4<f64>, p: &Point3<f64>) -> Point3<f64> {
+    let q = m * Point3::to_homogeneous(*p);
     Point3::from_homogeneous(q / q.w)
 }
 
@@ -97,7 +97,7 @@ fn clip_point_to_hemicube(p: &Point3<f64>) -> Point3<f64> {
 // proportional to the size on the screen, but this parameter would need to be passed through to
 // all API calls. I decided on relying on a 'good enough' metric instead which did not require the
 // parameter.
-fn relative_size_on_screen(bounding_cube: &Cube, matrix: &Matrix4<f32>) -> f64 {
+fn relative_size_on_screen(bounding_cube: &Cube, matrix: &Matrix4<f64>) -> f64 {
     // z is unused here.
     let min = bounding_cube.min();
     let max = bounding_cube.max();
@@ -166,7 +166,7 @@ impl<'a> InternalIterator for PointsInBoxIterator<'a> {
 
 pub struct PointsInFrustumIterator<'a> {
     octree: &'a Octree,
-    frustum_matrix: &'a Matrix4<f32>,
+    frustum_matrix: &'a Matrix4<f64>,
     intersecting_nodes: Vec<NodeId>,
 }
 
@@ -227,9 +227,9 @@ impl<'a> InternalIterator for AllPointsIterator<'a> {
 }
 
 // TODO(ksavinash9) update after https://github.com/rustgd/collision-rs/issues/101 is resolved.
-fn contains(projection_matrix: &Matrix4<f32>, point: &Point3<f64>) -> bool {
+fn contains(projection_matrix: &Matrix4<f64>, point: &Point3<f64>) -> bool {
     let v = Vector4::new(point.x, point.y, point.z, 1.);
-    let clip_v = projection_matrix.cast::<f64>().unwrap() * v;
+    let clip_v = projection_matrix * v;
     clip_v.x.abs() < clip_v.w && clip_v.y.abs() < clip_v.w && 0. < clip_v.z && clip_v.z < clip_v.w
 }
 
@@ -313,8 +313,8 @@ impl Octree {
         to_meta_proto(&self.meta, nodes)
     }
 
-    pub fn get_visible_nodes(&self, projection_matrix: &Matrix4<f32>) -> Vec<NodeId> {
-        let frustum = Frustum::from_matrix4(projection_matrix.cast::<f64>().unwrap()).unwrap();
+    pub fn get_visible_nodes(&self, projection_matrix: &Matrix4<f64>) -> Vec<NodeId> {
+        let frustum = Frustum::from_matrix4(*projection_matrix).unwrap();
         let mut open = BinaryHeap::new();
         maybe_push_node(
             &mut open,
@@ -417,7 +417,7 @@ impl Octree {
 
     pub fn points_in_frustum<'a>(
         &'a self,
-        frustum_matrix: &'a Matrix4<f32>,
+        frustum_matrix: &'a Matrix4<f64>,
     ) -> PointsInFrustumIterator<'a> {
         let intersecting_nodes = self.get_visible_nodes(frustum_matrix);
         PointsInFrustumIterator {
@@ -477,7 +477,7 @@ fn maybe_push_node(
     nodes: &FnvHashMap<NodeId, NodeMeta>,
     relation: Relation,
     node: Node,
-    projection_matrix: &Matrix4<f32>,
+    projection_matrix: &Matrix4<f64>,
 ) {
     if !nodes.contains_key(&node.id) {
         return;


### PR DESCRIPTION
Currently when navigating an octree covering the earth, moving around feels like going in steps. This is due to the limited f32 resolution of the translational part of the projection matrix. This PR updates the matrix to an f64 based one, removing the "stuttering".