### PR TITLE
Replace iterators with default ones for more flexibility.

### DIFF
--- a/point_viewer_grpc/src/bin/octree_benchmark.rs
+++ b/point_viewer_grpc/src/bin/octree_benchmark.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use point_viewer::octree::{octree_from_directory, OctreeFactory};
-use point_viewer::{InternalIterator, Point};
+use point_viewer::Point;
 use point_viewer_grpc::proto_grpc::OctreeClient;
 use point_viewer_grpc::service::start_grpc_server;
 use point_viewer_grpc_proto_rust::proto;
@@ -71,11 +71,11 @@ fn server_benchmark(octree_directory: &Path, num_points: u64) {
         )
     });
     let mut counter: u64 = 0;
-    octree.all_points().for_each(|_p: &Point| {
+    octree.all_points().for_each(|p: Vec<Point>| {
         if counter % 1_000_000 == 0 {
             println!("Streamed {}M points", counter / 1_000_000);
         }
-        counter += 1;
+        counter += p.len() as u64;
         if counter == num_points {
             std::process::exit(0)
         }

--- a/point_viewer_grpc/src/bin/octree_benchmark.rs
+++ b/point_viewer_grpc/src/bin/octree_benchmark.rs
@@ -71,14 +71,12 @@ fn server_benchmark(octree_directory: &Path, num_points: u64) {
         )
     });
     let mut counter: u64 = 0;
-    let mut num_prints: u64 = 1;
-    octree.all_points().for_each(|pts: Vec<Point>| {
-        counter += pts.len() as u64;
-        if counter >= num_prints * 1_000_000 {
+    octree.all_points().for_each(|_p: Point| {
+        if counter % 1_000_000 == 0 {
             println!("Streamed {}M points", counter / 1_000_000);
-            num_prints += 1;
         }
-        if counter >= num_points {
+        counter += 1;
+        if counter == num_points {
             std::process::exit(0)
         }
     });

--- a/point_viewer_grpc/src/bin/octree_benchmark.rs
+++ b/point_viewer_grpc/src/bin/octree_benchmark.rs
@@ -72,8 +72,8 @@ fn server_benchmark(octree_directory: &Path, num_points: u64) {
     });
     let mut counter: u64 = 0;
     let mut num_prints: u64 = 1;
-    octree.all_points().for_each(|p: Vec<Point>| {
-        counter += p.len() as u64;
+    octree.all_points().for_each(|pts: Vec<Point>| {
+        counter += pts.len() as u64;
         if counter >= num_prints * 1_000_000 {
             println!("Streamed {}M points", counter / 1_000_000);
             num_prints += 1;

--- a/point_viewer_grpc/src/bin/octree_benchmark.rs
+++ b/point_viewer_grpc/src/bin/octree_benchmark.rs
@@ -71,12 +71,14 @@ fn server_benchmark(octree_directory: &Path, num_points: u64) {
         )
     });
     let mut counter: u64 = 0;
+    let mut num_prints: u64 = 1;
     octree.all_points().for_each(|p: Vec<Point>| {
-        if counter % 1_000_000 == 0 {
-            println!("Streamed {}M points", counter / 1_000_000);
-        }
         counter += p.len() as u64;
-        if counter == num_points {
+        if counter >= num_prints * 1_000_000 {
+            println!("Streamed {}M points", counter / 1_000_000);
+            num_prints += 1;
+        }
+        if counter >= num_points {
             std::process::exit(0)
         }
     });

--- a/point_viewer_grpc/src/bin/query_frustum.rs
+++ b/point_viewer_grpc/src/bin/query_frustum.rs
@@ -19,10 +19,9 @@ use futures::{Future, Stream};
 use grpcio::{ChannelBuilder, EnvBuilder};
 use point_viewer::color::Color;
 use point_viewer::generation::build_octree;
-use point_viewer::{Point, NUM_POINTS_PER_BATCH};
+use point_viewer::Point;
 pub use point_viewer_grpc_proto_rust::proto::GetPointsInFrustumRequest;
 pub use point_viewer_grpc_proto_rust::proto_grpc;
-use std::iter::FromIterator;
 use std::sync::Arc;
 
 struct Points {
@@ -40,18 +39,17 @@ impl Points {
 }
 
 impl Iterator for Points {
-    type Item = Vec<Point>;
+    type Item = Point;
 
-    fn next(&mut self) -> Option<Vec<Point>> {
+    fn next(&mut self) -> Option<Point> {
         if self.point_count == self.points.len() {
             return None;
         }
-        let start = self.point_count;
-        let end = std::cmp::min(self.point_count + NUM_POINTS_PER_BATCH, self.points.len());
-        let points = Vec::from_iter(self.points[start..end].iter().cloned());
-        self.point_count = end;
-        Some(points)
+        let point = self.points[self.point_count].clone();
+        self.point_count += 1;
+        Some(point)
     }
+
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.points.len(), Some(self.points.len()))
     }

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -236,38 +236,36 @@ impl OctreeService {
 
             {
                 // Extra scope to make sure that 'func' does not outlive 'reply'.
-                let func = |pts: Vec<Point>| {
-                    for p in pts {
-                        {
-                            let mut v = point_viewer::proto::Vector3d::new();
-                            v.set_x(p.position.x);
-                            v.set_y(p.position.y);
-                            v.set_z(p.position.z);
-                            reply.mut_positions().push(v);
-                        }
+                let func = |p: Point| {
+                    {
+                        let mut v = point_viewer::proto::Vector3d::new();
+                        v.set_x(p.position.x);
+                        v.set_y(p.position.y);
+                        v.set_z(p.position.z);
+                        reply.mut_positions().push(v);
+                    }
 
-                        {
-                            let mut v = point_viewer::proto::Color::new();
-                            let clr = p.color.to_f32();
-                            v.set_red(clr.red);
-                            v.set_green(clr.green);
-                            v.set_blue(clr.blue);
-                            v.set_alpha(clr.alpha);
-                            reply.mut_colors().push(v);
-                        }
+                    {
+                        let mut v = point_viewer::proto::Color::new();
+                        let clr = p.color.to_f32();
+                        v.set_red(clr.red);
+                        v.set_green(clr.green);
+                        v.set_blue(clr.blue);
+                        v.set_alpha(clr.alpha);
+                        reply.mut_colors().push(v);
+                    }
 
-                        if let Some(i) = p.intensity {
-                            reply.mut_intensities().push(i);
-                        }
+                    if let Some(i) = p.intensity {
+                        reply.mut_intensities().push(i);
+                    }
 
-                        reply_size += bytes_per_point;
-                        if reply_size > max_message_size - bytes_per_point {
-                            tx.send((reply.clone(), WriteFlags::default())).unwrap();
-                            reply.mut_positions().clear();
-                            reply.mut_colors().clear();
-                            reply.mut_intensities().clear();
-                            reply_size = 0;
-                        }
+                    reply_size += bytes_per_point;
+                    if reply_size > max_message_size - bytes_per_point {
+                        tx.send((reply.clone(), WriteFlags::default())).unwrap();
+                        reply.mut_positions().clear();
+                        reply.mut_colors().clear();
+                        reply.mut_intensities().clear();
+                        reply_size = 0;
                     }
                 };
                 match query {

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -24,7 +24,7 @@ use grpcio::{
 };
 use point_viewer::errors::*;
 use point_viewer::octree::{NodeId, Octree, OctreeFactory};
-use point_viewer::{InternalIterator, Point};
+use point_viewer::Point;
 use protobuf::Message;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -236,36 +236,38 @@ impl OctreeService {
 
             {
                 // Extra scope to make sure that 'func' does not outlive 'reply'.
-                let func = |p: &Point| {
-                    {
-                        let mut v = point_viewer::proto::Vector3d::new();
-                        v.set_x(p.position.x);
-                        v.set_y(p.position.y);
-                        v.set_z(p.position.z);
-                        reply.mut_positions().push(v);
-                    }
+                let func = |pts: Vec<Point>| {
+                    for p in pts {
+                        {
+                            let mut v = point_viewer::proto::Vector3d::new();
+                            v.set_x(p.position.x);
+                            v.set_y(p.position.y);
+                            v.set_z(p.position.z);
+                            reply.mut_positions().push(v);
+                        }
 
-                    {
-                        let mut v = point_viewer::proto::Color::new();
-                        let clr = p.color.to_f32();
-                        v.set_red(clr.red);
-                        v.set_green(clr.green);
-                        v.set_blue(clr.blue);
-                        v.set_alpha(clr.alpha);
-                        reply.mut_colors().push(v);
-                    }
+                        {
+                            let mut v = point_viewer::proto::Color::new();
+                            let clr = p.color.to_f32();
+                            v.set_red(clr.red);
+                            v.set_green(clr.green);
+                            v.set_blue(clr.blue);
+                            v.set_alpha(clr.alpha);
+                            reply.mut_colors().push(v);
+                        }
 
-                    if let Some(i) = p.intensity {
-                        reply.mut_intensities().push(i);
-                    }
+                        if let Some(i) = p.intensity {
+                            reply.mut_intensities().push(i);
+                        }
 
-                    reply_size += bytes_per_point;
-                    if reply_size > max_message_size - bytes_per_point {
-                        tx.send((reply.clone(), WriteFlags::default())).unwrap();
-                        reply.mut_positions().clear();
-                        reply.mut_colors().clear();
-                        reply.mut_intensities().clear();
-                        reply_size = 0;
+                        reply_size += bytes_per_point;
+                        if reply_size > max_message_size - bytes_per_point {
+                            tx.send((reply.clone(), WriteFlags::default())).unwrap();
+                            reply.mut_positions().clear();
+                            reply.mut_colors().clear();
+                            reply.mut_intensities().clear();
+                            reply_size = 0;
+                        }
                     }
                 };
                 match query {

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -457,6 +457,7 @@ mod tests {
     use crate::color::Color;
     use crate::NUM_POINTS_PER_BATCH;
     use cgmath::Vector3;
+    use num_traits::identities::Zero;
     use std::iter::FromIterator;
     use tempdir::TempDir;
 
@@ -495,7 +496,7 @@ mod tests {
     #[test]
     fn test_generation() {
         let default_point = Point {
-            position: Vector3::new(0.0, 0.0, 0.0),
+            position: Vector3::zero(),
             color: Color {
                 red: 255,
                 green: 0,

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -18,7 +18,7 @@ use crate::octree::{self, to_meta_proto, to_node_proto, OnDiskOctreeDataProvider
 use crate::ply::PlyIterator;
 use crate::proto;
 use crate::pts::PtsIterator;
-use crate::{InternalIterator, Point};
+use crate::Point;
 use cgmath::{EuclideanSpace, Point3};
 use collision::{Aabb, Aabb3};
 use fnv::{FnvHashMap, FnvHashSet};
@@ -43,35 +43,37 @@ fn split<P>(
     stream: P,
 ) -> (Vec<octree::NodeId>, Vec<octree::NodeId>)
 where
-    P: InternalIterator,
+    P: Iterator<Item = Vec<Point>>,
 {
     let mut children: Vec<Option<octree::NodeWriter>> =
         vec![None, None, None, None, None, None, None, None];
     match stream.size_hint() {
-        Some(size) => println!(
+        (_, Some(size)) => println!(
             "Splitting {} which has {} points ({:.2}x MAX_POINTS_PER_NODE).",
             node_id,
             size,
             size as f64 / MAX_POINTS_PER_NODE as f64
         ),
-        None => println!(
+        (_, None) => println!(
             "Splitting {} which has an unknown number of points.",
             node_id
         ),
     };
 
     let bounding_cube = node_id.find_bounding_cube(&Cube::bounding(&octree_meta.bounding_box));
-    stream.for_each(|p| {
-        let child_index = octree::ChildIndex::from_bounding_cube(&bounding_cube, &p.position);
-        let array_index = child_index.as_u8() as usize;
-        if children[array_index].is_none() {
-            children[array_index] = Some(octree::NodeWriter::new(
-                octree_data_provider,
-                octree_meta,
-                &node_id.get_child_id(child_index),
-            ));
+    stream.for_each(|pts| {
+        for p in pts {
+            let child_index = octree::ChildIndex::from_bounding_cube(&bounding_cube, &p.position);
+            let array_index = child_index.as_u8() as usize;
+            if children[array_index].is_none() {
+                children[array_index] = Some(octree::NodeWriter::new(
+                    octree_data_provider,
+                    octree_meta,
+                    &node_id.get_child_id(child_index),
+                ));
+            }
+            children[array_index].as_mut().unwrap().write(&p);
         }
-        children[array_index].as_mut().unwrap().write(p);
     });
 
     // Remove the node file on disk by reopening the node and immediately dropping it again without
@@ -130,7 +132,7 @@ fn split_node<'a, P>(
     stream: P,
     leaf_nodes_sender: &mpsc::Sender<octree::NodeId>,
 ) where
-    P: InternalIterator,
+    P: Iterator<Item = Vec<Point>>,
 {
     let (leaf_nodes, split_nodes) = split(octree_data_provider, octree_meta, node_id, stream);
     for child_id in split_nodes {
@@ -182,8 +184,8 @@ fn subsample_children_into(
 
         // We read all points into memory, because the new node writer will rewrite this child's
         // file(s).
-        let mut points = Vec::with_capacity(node_iterator.size_hint().unwrap());
-        node_iterator.for_each(|p| points.push((*p).clone()));
+        let mut points = Vec::with_capacity(node_iterator.size_hint().1.unwrap());
+        node_iterator.for_each(|mut pts| points.append(&mut pts));
 
         let mut child_writer =
             octree::NodeWriter::new(octree_data_provider, octree_meta, &child_id);
@@ -220,18 +222,20 @@ enum InputFileIterator {
     Pts(PtsIterator),
 }
 
-impl InternalIterator for InputFileIterator {
-    fn size_hint(&self) -> Option<usize> {
+impl Iterator for InputFileIterator {
+    type Item = Vec<Point>;
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
         match *self {
             InputFileIterator::Ply(ref p) => p.size_hint(),
             InputFileIterator::Pts(ref p) => p.size_hint(),
         }
     }
 
-    fn for_each<F: FnMut(&Point)>(self, f: F) {
+    fn next(&mut self) -> Option<Vec<Point>> {
         match self {
-            InputFileIterator::Ply(p) => p.for_each(f),
-            InputFileIterator::Pts(p) => p.for_each(f),
+            InputFileIterator::Ply(p) => p.next(),
+            InputFileIterator::Pts(p) => p.next(),
         }
     }
 }
@@ -245,8 +249,8 @@ fn make_stream(input: &InputFile) -> (InputFileIterator, Option<ProgressBar<Stdo
     };
 
     let progress_bar = match stream.size_hint() {
-        Some(size) => Some(ProgressBar::new(size as u64)),
-        None => None,
+        (_, Some(size)) => Some(ProgressBar::new(size as u64)),
+        (_, None) => None,
     };
     (stream, progress_bar)
 }
@@ -268,15 +272,17 @@ fn find_bounding_box(input: &InputFile) -> Aabb3<f64> {
         pb.message("Determining bounding box: ")
     }
 
-    stream.for_each(|p: &Point| {
-        if num_points == 0 {
-            let p3 = Point3::from_vec(p.position);
-            bounding_box = Aabb3::new(p3, p3);
-        }
-        bounding_box = bounding_box.grow(Point3::from_vec(p.position));
-        num_points += 1;
-        if num_points % UPDATE_COUNT == 0 {
-            progress_bar.as_mut().map(|pb| pb.add(UPDATE_COUNT as u64));
+    stream.for_each(|pts| {
+        for p in pts {
+            if num_points == 0 {
+                let p3 = Point3::from_vec(p.position);
+                bounding_box = Aabb3::new(p3, p3);
+            }
+            bounding_box = bounding_box.grow(Point3::from_vec(p.position));
+            num_points += 1;
+            if num_points % UPDATE_COUNT == 0 {
+                progress_bar.as_mut().map(|pb| pb.add(UPDATE_COUNT as u64));
+            }
         }
     });
     if let Some(mut f) = progress_bar {
@@ -320,7 +326,7 @@ pub fn build_octree(
     output_directory: impl AsRef<Path>,
     resolution: f64,
     bounding_box: Aabb3<f64>,
-    input: impl InternalIterator,
+    input: impl Iterator<Item = Vec<Point>>,
 ) {
     // We open a lot of files during our work. Sometimes users see errors with 'cannot open more
     // files'. We attempt to increase the rlimits for the number of open files per process here,
@@ -449,21 +455,41 @@ pub fn build_octree(
 mod tests {
     use super::*;
     use crate::color::Color;
+    use crate::NUM_POINTS_PER_BATCH;
     use cgmath::Vector3;
+    use std::iter::FromIterator;
     use tempdir::TempDir;
 
     struct Points {
         points: Vec<Point>,
+        point_count: usize,
     }
 
-    impl InternalIterator for Points {
-        fn for_each<F: FnMut(&Point)>(self, mut func: F) {
-            for p in &self.points {
-                func(p);
+    impl Points {
+        fn new(points: Vec<Point>) -> Self {
+            Points {
+                points,
+                point_count: 0,
             }
         }
-        fn size_hint(&self) -> Option<usize> {
-            Some(self.points.len())
+    }
+
+    impl Iterator for Points {
+        type Item = Vec<Point>;
+
+        fn next(&mut self) -> Option<Vec<Point>> {
+            if self.point_count == self.points.len() {
+                return None;
+            }
+            let start = self.point_count;
+            let end = std::cmp::min(self.point_count + NUM_POINTS_PER_BATCH, self.points.len());
+            let points = Vec::from_iter(self.points[start..end].iter().cloned());
+            self.point_count = end;
+            Some(points)
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (self.points.len(), Some(self.points.len()))
         }
     }
     #[test]
@@ -486,6 +512,6 @@ mod tests {
         }
         let pool = scoped_pool::Pool::new(10);
         let tmp_dir = TempDir::new("octree").unwrap();
-        build_octree(&pool, tmp_dir, 1.0, bounding_box, Points { points });
+        build_octree(&pool, tmp_dir, 1.0, bounding_box, Points::new(points));
     }
 }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -183,7 +183,7 @@ fn subsample_children_into(
         // We read all points into memory, because the new node writer will rewrite this child's
         // file(s).
         let mut points = Vec::with_capacity(node_iterator.size_hint().1.unwrap());
-        node_iterator.for_each(|p| points.push(p.clone()));
+        node_iterator.for_each(|p| points.push(p));
 
         let mut child_writer =
             octree::NodeWriter::new(octree_data_provider, octree_meta, &child_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,6 @@ pub mod octree;
 pub mod ply;
 pub mod pts;
 
-// Assuming 20 - 40 bytes per point, this translates to 10-20MB per points batch.
-pub const NUM_POINTS_PER_BATCH: usize = 500_000;
-
 #[derive(Debug, Clone)]
 pub struct Point {
     pub position: cgmath::Vector3<f64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,10 +28,8 @@ pub mod octree;
 pub mod ply;
 pub mod pts;
 
-pub trait InternalIterator {
-    fn for_each<F: FnMut(&Point)>(self, _: F);
-    fn size_hint(&self) -> Option<usize>;
-}
+// Assuming 20 - 40 bytes per point, this translates to 10-20MB per points batch.
+pub const NUM_POINTS_PER_BATCH: usize = 500_000;
 
 #[derive(Debug, Clone)]
 pub struct Point {

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -434,7 +434,7 @@ impl Octree {
     }
 
     pub fn all_points(&self) -> AllPointsIterator {
-        let mut node_ids = VecDeque::new();
+        let mut node_ids = VecDeque::with_capacity(self.nodes.len());
         let mut open_list = vec![NodeId::from_level_index(0, 0)];
         while !open_list.is_empty() {
             let current = open_list.pop().unwrap();

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -182,7 +182,7 @@ impl<'a> Iterator for PointsIterator<'a> {
             match node_iterator.next() {
                 Some(point) => {
                     if (self.filter_func)(&point) {
-                        return Some(point.clone());
+                        return Some(point);
                     }
                 }
                 None => self.node_iterator = None,

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -138,7 +138,7 @@ pub struct PointsIterator<'a> {
     filter_func: Box<Fn(&Point) -> bool + 'a>,
     node_ids: VecDeque<NodeId>,
     node_iterator: Option<NodeIterator>,
-    queued_points: VecDeque<Point>,
+    queued_points: Vec<Point>,
 }
 
 impl<'a> PointsIterator<'a> {
@@ -152,7 +152,7 @@ impl<'a> PointsIterator<'a> {
             filter_func,
             node_ids,
             node_iterator: None,
-            queued_points: VecDeque::new(),
+            queued_points: Vec::new(),
         }
     }
 }

--- a/src/octree/node_iterator.rs
+++ b/src/octree/node_iterator.rs
@@ -1,11 +1,11 @@
 use crate::codec::{decode, fixpoint_decode};
-use crate::color;
 use crate::errors::*;
 use crate::math::Cube;
 use crate::octree::{
     NodeId, NodeLayer, NodeMeta, OctreeDataProvider, OctreeMeta, PositionEncoding,
 };
-use crate::{InternalIterator, Point};
+use crate::Point;
+use crate::{color::Color, NUM_POINTS_PER_BATCH};
 use byteorder::{LittleEndian, ReadBytesExt};
 use cgmath::Vector3;
 use num_traits::identities::Zero;
@@ -17,6 +17,7 @@ pub struct NodeIteratorWithData {
     rgb_reader: BufReader<Box<dyn Read>>,
     intensity_reader: Option<BufReader<Box<dyn Read>>>,
     meta: NodeMeta,
+    point_count: usize,
 }
 
 pub enum NodeIterator {
@@ -65,105 +66,124 @@ impl NodeIterator {
                 position_encoding,
                 num_points,
             },
+            point_count: 0,
         };
         Ok(NodeIterator::WithData(iter))
     }
 }
 
-impl InternalIterator for NodeIterator {
-    fn size_hint(&self) -> Option<usize> {
-        match self {
-            NodeIterator::WithData(ref iter) => Some(iter.meta.num_points as usize),
-            NodeIterator::Empty => Some(0),
-        }
+impl Iterator for NodeIterator {
+    type Item = Vec<Point>;
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let num_points = match self {
+            NodeIterator::WithData(ref iter) => iter.meta.num_points as usize,
+            NodeIterator::Empty => 0,
+        };
+        (num_points, Some(num_points))
     }
-    fn for_each<F: FnMut(&Point)>(self, mut f: F) {
+    fn next(&mut self) -> Option<Vec<Point>> {
         let mut iter = match self {
             NodeIterator::WithData(iter) => iter,
-            NodeIterator::Empty => return,
+            NodeIterator::Empty => return None,
         };
 
-        let mut point = Point {
-            position: Vector3::zero(),
-            color: color::RED.to_u8(), // is overwritten
-            intensity: None,
-        };
+        if iter.point_count == iter.meta.num_points as usize {
+            return None;
+        }
+
+        let mut points = Vec::with_capacity(NUM_POINTS_PER_BATCH);
 
         let edge_length = iter.meta.bounding_cube.edge_length();
         let min = iter.meta.bounding_cube.min();
-        for _ in 0..iter.meta.num_points {
+        for _ in iter.point_count
+            ..std::cmp::min(
+                iter.point_count + NUM_POINTS_PER_BATCH,
+                iter.meta.num_points as usize,
+            )
+        {
             // I tried pulling out this match by taking a function pointer to a 'decode_position'
             // function. This replaces a branch per point vs a function call per point and turned
             // out to be marginally slower.
+            let mut position = Vector3::zero();
             match iter.meta.position_encoding {
                 PositionEncoding::Float32 => {
-                    point.position.x = decode(
+                    position.x = decode(
                         iter.xyz_reader.read_f32::<LittleEndian>().unwrap(),
                         min.x,
                         edge_length,
                     );
-                    point.position.y = decode(
+                    position.y = decode(
                         iter.xyz_reader.read_f32::<LittleEndian>().unwrap(),
                         min.y,
                         edge_length,
                     );
-                    point.position.z = decode(
+                    position.z = decode(
                         iter.xyz_reader.read_f32::<LittleEndian>().unwrap(),
                         min.z,
                         edge_length,
                     );
                 }
                 PositionEncoding::Float64 => {
-                    point.position.x = decode(
+                    position.x = decode(
                         iter.xyz_reader.read_f64::<LittleEndian>().unwrap(),
                         min.x,
                         edge_length,
                     );
-                    point.position.y = decode(
+                    position.y = decode(
                         iter.xyz_reader.read_f64::<LittleEndian>().unwrap(),
                         min.y,
                         edge_length,
                     );
-                    point.position.z = decode(
+                    position.z = decode(
                         iter.xyz_reader.read_f64::<LittleEndian>().unwrap(),
                         min.z,
                         edge_length,
                     );
                 }
                 PositionEncoding::Uint8 => {
-                    point.position.x =
+                    position.x =
                         fixpoint_decode(iter.xyz_reader.read_u8().unwrap(), min.x, edge_length);
-                    point.position.y =
+                    position.y =
                         fixpoint_decode(iter.xyz_reader.read_u8().unwrap(), min.y, edge_length);
-                    point.position.z =
+                    position.z =
                         fixpoint_decode(iter.xyz_reader.read_u8().unwrap(), min.z, edge_length);
                 }
                 PositionEncoding::Uint16 => {
-                    point.position.x = fixpoint_decode(
+                    position.x = fixpoint_decode(
                         iter.xyz_reader.read_u16::<LittleEndian>().unwrap(),
                         min.x,
                         edge_length,
                     );
-                    point.position.y = fixpoint_decode(
+                    position.y = fixpoint_decode(
                         iter.xyz_reader.read_u16::<LittleEndian>().unwrap(),
                         min.y,
                         edge_length,
                     );
-                    point.position.z = fixpoint_decode(
+                    position.z = fixpoint_decode(
                         iter.xyz_reader.read_u16::<LittleEndian>().unwrap(),
                         min.z,
                         edge_length,
                     );
                 }
             }
-
-            point.color.red = iter.rgb_reader.read_u8().unwrap();
-            point.color.green = iter.rgb_reader.read_u8().unwrap();
-            point.color.blue = iter.rgb_reader.read_u8().unwrap();
-            if let Some(ir) = iter.intensity_reader.as_mut() {
-                point.intensity = Some(ir.read_f32::<LittleEndian>().unwrap());
-            }
-            f(&point);
+            let color = Color {
+                red: iter.rgb_reader.read_u8().unwrap(),
+                green: iter.rgb_reader.read_u8().unwrap(),
+                blue: iter.rgb_reader.read_u8().unwrap(),
+                alpha: 255,
+            };
+            let intensity = iter
+                .intensity_reader
+                .as_mut()
+                .map(|ir| ir.read_f32::<LittleEndian>().unwrap());
+            points.push(Point {
+                position,
+                color,
+                intensity,
+            });
+            iter.point_count += 1;
         }
+        Some(points)
     }
 }

--- a/src/octree/node_iterator.rs
+++ b/src/octree/node_iterator.rs
@@ -176,6 +176,6 @@ impl Iterator for NodeIterator {
             .map(|ir| ir.read_f32::<LittleEndian>().unwrap());
         iter.point_count += 1;
 
-        Some(point.clone())
+        Some(point)
     }
 }

--- a/src/ply.rs
+++ b/src/ply.rs
@@ -17,6 +17,7 @@ use crate::errors::*;
 use crate::{Point, NUM_POINTS_PER_BATCH};
 use byteorder::{ByteOrder, LittleEndian};
 use cgmath::Vector3;
+use num_traits::identities::Zero;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use std::ops::Index;
@@ -121,7 +122,7 @@ fn parse_header<R: BufRead>(reader: &mut R) -> Result<(Header, usize)> {
 
     let mut format = None;
     let mut current_element = None;
-    let mut offset = Vector3::new(0., 0., 0.);
+    let mut offset = Vector3::zero();
     let mut elements = Vec::new();
     loop {
         line.clear();
@@ -409,7 +410,7 @@ impl Iterator for PlyIterator {
             )
         {
             let mut point = Point {
-                position: Vector3::new(0., 0., 0.),
+                position: Vector3::zero(),
                 color: color::WHITE.to_u8(),
                 intensity: None,
             };

--- a/src/pts.rs
+++ b/src/pts.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::color::Color;
-use crate::{Point, NUM_POINTS_PER_BATCH};
+use crate::Point;
 use cgmath::Vector3;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -36,12 +36,11 @@ impl PtsIterator {
 }
 
 impl Iterator for PtsIterator {
-    type Item = Vec<Point>;
+    type Item = Point;
 
-    fn next(&mut self) -> Option<Vec<Point>> {
-        let mut points = Vec::with_capacity(NUM_POINTS_PER_BATCH);
+    fn next(&mut self) -> Option<Point> {
         let mut line = String::new();
-        for _ in self.point_count..self.point_count + NUM_POINTS_PER_BATCH {
+        loop {
             line.clear();
             self.data.read_line(&mut line).unwrap();
             if line.is_empty() {
@@ -52,7 +51,8 @@ impl Iterator for PtsIterator {
             if parts.len() != 7 {
                 continue;
             }
-            points.push(Point {
+            self.point_count += 1;
+            return Some(Point {
                 position: Vector3::new(
                     parts[0].parse::<f64>().unwrap(),
                     parts[1].parse::<f64>().unwrap(),
@@ -66,12 +66,7 @@ impl Iterator for PtsIterator {
                 },
                 intensity: None,
             });
-            self.point_count += 1;
         }
-        if points.is_empty() {
-            None
-        } else {
-            Some(points)
-        }
+        None
     }
 }

--- a/src/pts.rs
+++ b/src/pts.rs
@@ -22,7 +22,6 @@ use std::path::Path;
 #[derive(Debug)]
 pub struct PtsIterator {
     data: BufReader<File>,
-    point_count: usize,
 }
 
 impl PtsIterator {
@@ -30,7 +29,6 @@ impl PtsIterator {
         let file = File::open(filename).unwrap();
         PtsIterator {
             data: BufReader::new(file),
-            point_count: 0,
         }
     }
 }
@@ -51,7 +49,6 @@ impl Iterator for PtsIterator {
             if parts.len() != 7 {
                 continue;
             }
-            self.point_count += 1;
             return Some(Point {
                 position: Vector3::new(
                     parts[0].parse::<f64>().unwrap(),

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -381,20 +381,17 @@ pub fn xray_from_points(
     tile_background_color: Color<u8>,
 ) -> bool {
     let mut seen_any_points = false;
-    octree.points_in_box(bbox).for_each(|pts| {
-        for p in &pts {
-            seen_any_points = true;
-            // We want a right handed coordinate system with the x-axis of world and images aligning.
-            // This means that the y-axis aligns too, but the origin of the image space must be at the
-            // bottom left. Since images have their origin at the top left, we need actually have to
-            // invert y and go from the bottom of the image.
-            let x =
-                (((p.position.x - bbox.min().x) / bbox.dim().x) * f64::from(image_width)) as u32;
-            let y = ((1. - ((p.position.y - bbox.min().y) / bbox.dim().y))
-                * f64::from(image_height)) as u32;
-            let z = (((p.position.z - bbox.min().z) / bbox.dim().z) * NUM_Z_BUCKETS) as u32;
-            coloring_strategy.process_discretized_point(p, x, y, z);
-        }
+    octree.points_in_box(bbox).for_each(|p| {
+        seen_any_points = true;
+        // We want a right handed coordinate system with the x-axis of world and images aligning.
+        // This means that the y-axis aligns too, but the origin of the image space must be at the
+        // bottom left. Since images have their origin at the top left, we need actually have to
+        // invert y and go from the bottom of the image.
+        let x = (((p.position.x - bbox.min().x) / bbox.dim().x) * f64::from(image_width)) as u32;
+        let y = ((1. - ((p.position.y - bbox.min().y) / bbox.dim().y)) * f64::from(image_height))
+            as u32;
+        let z = (((p.position.z - bbox.min().z) / bbox.dim().z) * NUM_Z_BUCKETS) as u32;
+        coloring_strategy.process_discretized_point(&p, x, y, z);
     });
 
     if !seen_any_points {


### PR DESCRIPTION
- The current node, point, and file iterators are based on a custom one only providing a `for_each` method.
- This is pretty inflexible, in particular when we want to cancel iteration, which is e.g. possible with the default iterators by using [`try_for_each`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.try_for_each).
- Furthermore, by moving to default iterators we get all the functionality of the [iterator trait](https://doc.rust-lang.org/std/iter/trait.Iterator.html).
- A drawback is that the new iterators are slightly slower, since more function calls are involved:
  - `target/release/build_octree /Users/mfeuerstein/dev/slam_assets/e318a37b-a481-4b93-8d07-f0358b71bf22/pointcloud_just_colors.ply --output_directory /Users/mfeuerstein/dev/slam_assets/e318a37b-a481-4b93-8d07-f0358b71bf22/octree_just_colors/`:
    - old:
       User time (seconds): 979.59
       System time (seconds): 251.63
       Percent of CPU this job got: 506%
       Elapsed (wall clock) time (h:mm:ss or m:ss): 4:02.86
    - new:
	User time (seconds): 1178.92
	System time (seconds): 242.69
	Percent of CPU this job got: 517%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 4:34.66
  - `target/release/octree_benchmark /Users/mfeuerstein/dev/slam_assets/fd93587d-2c3d-48f9-8e52-1f9c0f541d86/octree_just_colors/ --no-client`
    - old:
	User time (seconds): 2.16
	System time (seconds): 0.32
	Percent of CPU this job got: 99%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:02.49
    - new:
	User time (seconds): 3.95
	System time (seconds): 0.33
	Percent of CPU this job got: 99%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:04.29
  - `target/release/octree_benchmark /Users/mfeuerstein/dev/slam_assets/fd93587d-2c3d-48f9-8e52-1f9c0f541d86/octree_just_colors/`
    - old:
	User time (seconds): 10.75
	System time (seconds): 2.81
	Percent of CPU this job got: 113%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:11.99
    - new:
	User time (seconds): 10.28
	System time (seconds): 2.70
	Percent of CPU this job got: 112%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:11.56
- If we later need an iterator pointing to references of points, we can consider switching to the https://docs.rs/streaming-iterator/0.1.4/streaming_iterator/