### PR TITLE
Handle special case of OrientedBeam query

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -165,6 +165,7 @@ impl OrientedBeam {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cgmath::Zero;
     // These tests were created in Blender by creating two cubes, naming one
     // "Beam" and scaling it up in its local z direction. The corresponding
     // object in Rust was defined by querying Blender's Python API with


### PR DESCRIPTION
When the orientation of the beam is aligned with a basis vector, the cross product becomes zero, and normalization produces NaNs. This taints the intersection computation and gives incorrect results (no points). 