### PR TITLE
Bugfix for ECEF octrees: visible nodes traversal

### DIFF
--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -358,7 +358,12 @@ impl Octree {
                     unreachable!();
                 }
             };
-            if self.nodes.get(&current.node.id).map_or(0, |meta| meta.num_points) > 0 {
+            if self
+                .nodes
+                .get(&current.node.id)
+                .map_or(0, |meta| meta.num_points)
+                > 0
+            {
                 visible.push(current.node.id);
             }
         }
@@ -496,7 +501,7 @@ fn maybe_push_node(
     node: Node,
     projection_matrix: &Matrix4<f64>,
 ) {
-    if nodes.get(&node.id).map_or(0, |meta| meta.num_points) == 0 {
+    if !nodes.contains_key(&node.id) {
         return;
     }
     let size_on_screen = relative_size_on_screen(&node.bounding_cube, projection_matrix);

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -358,12 +358,7 @@ impl Octree {
                     unreachable!();
                 }
             };
-            if self
-                .nodes
-                .get(&current.node.id)
-                .map_or(0, |meta| meta.num_points)
-                > 0
-            {
+            if !current.empty {
                 visible.push(current.node.id);
             }
         }
@@ -465,6 +460,7 @@ struct OpenNode {
     node: Node,
     relation: Relation,
     size_on_screen: f64,
+    empty: bool,
 }
 
 impl Ord for OpenNode {
@@ -501,13 +497,13 @@ fn maybe_push_node(
     node: Node,
     projection_matrix: &Matrix4<f64>,
 ) {
-    if !nodes.contains_key(&node.id) {
-        return;
+    if let Some(meta) = nodes.get(&node.id) {
+        let size_on_screen = relative_size_on_screen(&node.bounding_cube, projection_matrix);
+        v.push(OpenNode {
+            node,
+            relation,
+            size_on_screen,
+            empty: meta.num_points == 0,
+        });
     }
-    let size_on_screen = relative_size_on_screen(&node.bounding_cube, projection_matrix);
-    v.push(OpenNode {
-        node,
-        relation,
-        size_on_screen,
-    });
 }

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -358,7 +358,9 @@ impl Octree {
                     unreachable!();
                 }
             };
-            visible.push(current.node.id);
+            if self.nodes.get(&current.node.id).map_or(0, |meta| meta.num_points) > 0 {
+                visible.push(current.node.id);
+            }
         }
         visible
     }


### PR DESCRIPTION
Nikolai found out that the tree traversal for visible nodes in ecef was not successful when an empty node was encountered. Here the correction.