### PR TITLE
Bugfix octree factory

### DIFF
--- a/src/octree/factory.rs
+++ b/src/octree/factory.rs
@@ -31,9 +31,7 @@ impl OctreeFactory {
             if !octree_argument.starts_with(prefix) {
                 continue;
             }
-            if let Ok(o) = octree_factory_function(octree_argument) {
-                return Ok(o);
-            }
+           return Ok(octree_factory_function(octree_argument)?);
         }
 
         // If no octree was generated, create it from disk

--- a/src/octree/factory.rs
+++ b/src/octree/factory.rs
@@ -31,7 +31,7 @@ impl OctreeFactory {
             if !octree_argument.starts_with(prefix) {
                 continue;
             }
-           return octree_factory_function(octree_argument);
+            return octree_factory_function(octree_argument);
         }
 
         // If no octree was generated, create it from disk

--- a/src/octree/factory.rs
+++ b/src/octree/factory.rs
@@ -31,7 +31,7 @@ impl OctreeFactory {
             if !octree_argument.starts_with(prefix) {
                 continue;
             }
-           return Ok(octree_factory_function(octree_argument)?);
+           return octree_factory_function(octree_argument);
         }
 
         // If no octree was generated, create it from disk


### PR DESCRIPTION
this change let the errors  in the factory to be seen in the backtrace and not silently removed by the call of ondiskoctree.