### PR TITLE
Add OBB.

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -269,7 +269,7 @@ impl OrientedBeam {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cgmath::Zero;
+    use cgmath::{Rad, Rotation3, Zero};
     // These tests were created in Blender by creating two cubes, naming one
     // "Beam" and scaling it up in its local z direction. The corresponding
     // object in Rust was defined by querying Blender's Python API with
@@ -318,5 +318,25 @@ mod tests {
         let vertical_beam =
             OrientedBeam::new(Quaternion::zero(), Vector3::zero(), Vector2::new(1.0, 1.0));
         assert_eq!(vertical_beam.intersects(&bbox1), true);
+    }
+
+    #[test]
+    fn test_obb_intersects() {
+        let zero_rot: Quaternion<f64> = Rotation3::from_angle_z(Rad(0.0));
+        let fourty_five_deg_rot: Quaternion<f64> =
+            Rotation3::from_angle_z(Rad(std::f64::consts::PI / 4.0));
+        let arbitrary_rot: Quaternion<f64> =
+            Rotation3::from_axis_angle(Vector3::new(0.2, 0.5, -0.7), Rad(0.123));
+        let translation = Vector3::new(0.0, 0.0, 0.0);
+        let half_extent = Vector3::new(1.0, 2.0, 3.0);
+        let zero_obb = Obb::new(zero_rot, translation, half_extent);
+        let fourty_five_deg_obb = Obb::new(fourty_five_deg_rot, translation, half_extent);
+        let arbitrary_obb = Obb::new(arbitrary_rot, translation, half_extent);
+        let bbox = Aabb3::new(Point3::new(0.5, 1.0, -3.0), Point3::new(1.5, 3.0, 3.0));
+        assert_eq!(zero_obb.separating_axes.len(), 3);
+        assert_eq!(zero_obb.intersects(&bbox), true);
+        assert_eq!(fourty_five_deg_obb.separating_axes.len(), 5);
+        assert_eq!(fourty_five_deg_obb.intersects(&bbox), false);
+        assert_eq!(arbitrary_obb.separating_axes.len(), 15);
     }
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use cgmath::{EuclideanSpace, InnerSpace, Point3, Quaternion, Rotation, Vector2, Vector3};
+use cgmath::{
+    BaseFloat, EuclideanSpace, InnerSpace, Point3, Quaternion, Rotation, Vector2, Vector3,
+};
 use collision::{Aabb, Aabb3};
+use num_traits::Float;
 
 #[derive(Debug, Clone)]
 pub struct Cube {
@@ -68,6 +71,126 @@ impl Cube {
     }
 }
 
+// This guards against the separating axes being NaN, which may happen when the orientation aligns with the unit axes.
+fn is_finite<S: BaseFloat>(vec: &Vector3<S>) -> bool {
+    vec.x.is_finite() && vec.y.is_finite() && vec.z.is_finite()
+}
+
+fn intersects<S: BaseFloat>(
+    corners: &[Point3<S>],
+    separating_axes: &[Vector3<S>],
+    aabb: &Aabb3<S>,
+) -> bool {
+    // SAT algorithm
+    // https://gamedev.stackexchange.com/questions/44500/how-many-and-which-axes-to-use-for-3d-obb-collision-with-sat
+    for sep_axis in separating_axes.iter() {
+        // Project the cube and the box/beam onto that axis
+        let mut cube_min_proj: S = Float::max_value();
+        let mut cube_max_proj: S = Float::min_value();
+        for corner in aabb.to_corners().iter() {
+            let corner_proj = corner.dot(*sep_axis);
+            cube_min_proj = cube_min_proj.min(corner_proj);
+            cube_max_proj = cube_max_proj.max(corner_proj);
+        }
+        // Project corners of the box/beam onto that axis
+        let mut beam_min_proj: S = Float::max_value();
+        let mut beam_max_proj: S = Float::min_value();
+        for corner in corners.iter() {
+            let corner_proj = corner.dot(*sep_axis);
+            beam_min_proj = beam_min_proj.min(corner_proj);
+            beam_max_proj = beam_max_proj.max(corner_proj);
+        }
+        if beam_min_proj > cube_max_proj || beam_max_proj < cube_min_proj {
+            return false;
+        }
+    }
+    true
+}
+
+pub struct Obb<S> {
+    rotation_inv: Quaternion<S>,
+    translation_inv: Vector3<S>,
+    half_extent: Vector3<S>,
+    corners: [Point3<S>; 8],
+    separating_axes: Vec<Vector3<S>>,
+}
+
+impl<S: BaseFloat> Obb<S> {
+    pub fn new(rotation: Quaternion<S>, translation: Vector3<S>, half_extent: Vector3<S>) -> Self {
+        Obb {
+            rotation_inv: rotation.conjugate(),
+            translation_inv: -rotation.conjugate().rotate_vector(translation),
+            half_extent,
+            corners: Obb::precompute_corners(&rotation, &translation, &half_extent),
+            separating_axes: Obb::precompute_separating_axes(&rotation),
+        }
+    }
+
+    pub fn intersects(&self, aabb: &Aabb3<S>) -> bool {
+        intersects(&self.corners, &self.separating_axes, aabb)
+    }
+
+    pub fn contains(&self, p: &Point3<S>) -> bool {
+        let Point3 { x, y, z } = self.rotation_inv.rotate_point(*p) + self.translation_inv;
+        x.abs() <= self.half_extent.x
+            && y.abs() <= self.half_extent.y
+            && z.abs() <= self.half_extent.z
+    }
+
+    fn precompute_corners(
+        rotation: &Quaternion<S>,
+        translation: &Vector3<S>,
+        half_extent: &Vector3<S>,
+    ) -> [Point3<S>; 8] {
+        let transform =
+            |x: S, y: S, z: S| rotation.rotate_point(Point3::new(x, y, z)) + translation;
+        [
+            transform(-half_extent.x, -half_extent.y, -half_extent.z),
+            transform(half_extent.x, -half_extent.y, -half_extent.z),
+            transform(-half_extent.x, half_extent.y, -half_extent.z),
+            transform(half_extent.x, half_extent.y, -half_extent.z),
+            transform(-half_extent.x, -half_extent.y, half_extent.z),
+            transform(half_extent.x, -half_extent.y, half_extent.z),
+            transform(-half_extent.x, half_extent.y, half_extent.z),
+            transform(half_extent.x, half_extent.y, half_extent.z),
+        ]
+    }
+
+    fn precompute_separating_axes(rotation: &Quaternion<S>) -> Vec<Vector3<S>> {
+        let unit_x = Vector3::unit_x();
+        let unit_y = Vector3::unit_y();
+        let unit_z = Vector3::unit_z();
+        let rot_x = rotation.rotate_vector(unit_x);
+        let rot_y = rotation.rotate_vector(unit_y);
+        let rot_z = rotation.rotate_vector(unit_z);
+        let mut separating_axes = vec![unit_x, unit_y, unit_z];
+        for axis in &[
+            rot_x,
+            rot_y,
+            rot_z,
+            unit_x.cross(rot_x).normalize(),
+            unit_x.cross(rot_y).normalize(),
+            unit_x.cross(rot_z).normalize(),
+            unit_y.cross(rot_x).normalize(),
+            unit_y.cross(rot_y).normalize(),
+            unit_y.cross(rot_z).normalize(),
+            unit_z.cross(rot_x).normalize(),
+            unit_z.cross(rot_y).normalize(),
+            unit_z.cross(rot_z).normalize(),
+        ] {
+            let is_finite_and_non_parallel = is_finite(&axis)
+                && separating_axes.iter().all(|elem| {
+                    (elem - axis).magnitude() > S::default_epsilon()
+                        && (elem + axis).magnitude() > S::default_epsilon()
+                });
+            if is_finite_and_non_parallel {
+                separating_axes.push(*axis);
+            }
+        }
+        separating_axes
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct OrientedBeam {
     // The members here are an implementation detail and differ from the
@@ -78,7 +201,7 @@ pub struct OrientedBeam {
     translation_inv: Vector3<f64>,
     half_extent: Vector2<f64>,
     corners: [Point3<f64>; 4],
-    separating_axes: [Vector3<f64>; 5],
+    separating_axes: Vec<Vector3<f64>>,
 }
 
 impl OrientedBeam {
@@ -95,35 +218,9 @@ impl OrientedBeam {
             separating_axes: OrientedBeam::precompute_separating_axes(&rotation),
         }
     }
+
     pub fn intersects(&self, aabb: &Aabb3<f64>) -> bool {
-        // SAT algorithm
-        // https://gamedev.stackexchange.com/questions/44500/how-many-and-which-axes-to-use-for-3d-obb-collision-with-sat
-        for sep_axis in self.separating_axes.iter() {
-            if !sep_axis.x.is_finite() || !sep_axis.y.is_finite() || !sep_axis.z.is_finite() {
-                // This guards against the separating axes being NaN, which may happen when the orientation aligns with the unit axes.
-                continue;
-            }
-            // Project the cube and the beam onto that axis
-            let mut cube_min_proj = std::f64::MAX;
-            let mut cube_max_proj = std::f64::MIN;
-            for corner in aabb.to_corners().iter() {
-                let corner_proj = corner.dot(*sep_axis);
-                cube_min_proj = cube_min_proj.min(corner_proj);
-                cube_max_proj = cube_max_proj.max(corner_proj);
-            }
-            // Project four "vertices" of the beam onto that axis
-            let mut beam_min_proj = std::f64::MAX;
-            let mut beam_max_proj = std::f64::MIN;
-            for corner in self.corners.iter() {
-                let corner_proj = corner.dot(*sep_axis);
-                beam_min_proj = beam_min_proj.min(corner_proj);
-                beam_max_proj = beam_max_proj.max(corner_proj);
-            }
-            if beam_min_proj > cube_max_proj || beam_max_proj < cube_min_proj {
-                return false;
-            }
-        }
-        true
+        intersects(&self.corners, &self.separating_axes, aabb)
     }
 
     pub fn contains(&self, p: &Point3<f64>) -> bool {
@@ -147,18 +244,25 @@ impl OrientedBeam {
         ]
     }
 
-    fn precompute_separating_axes(rotation: &Quaternion<f64>) -> [Vector3<f64>; 5] {
+    // TODO(nnmm): Change the axes to describe a beam, which is finitie in one direction.
+    // Currently we have a beam which is infinite in both directions.
+    // If we defined a beam on one side of the earth pointing towards the sky,
+    // it will also collect points on the other side of the earth, which is undesired.
+    fn precompute_separating_axes(rotation: &Quaternion<f64>) -> Vec<Vector3<f64>> {
         // The separating axis needs to be perpendicular to the beam's main
         // axis, i.e. the possible axes are the cross product of the three unit
         // vectors with the beam's main axis and the beam's face normals.
         let main_axis = rotation.rotate_vector(Vector3::unit_z());
-        [
+        vec![
             rotation.rotate_vector(Vector3::unit_x()),
             rotation.rotate_vector(Vector3::unit_y()),
             main_axis.cross(Vector3::unit_x()).normalize(),
             main_axis.cross(Vector3::unit_y()).normalize(),
             main_axis.cross(Vector3::unit_z()).normalize(),
         ]
+        .into_iter()
+        .filter(is_finite)
+        .collect()
     }
 }
 


### PR DESCRIPTION
We want to extend iterators to take local transformations. In order to implement all of them properly, we need an object oriented bounding box, so we can transform an aabb properly. 