### PR TITLE
Add point cloud client.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,7 +1511,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "point_cloud"
+name = "point_cloud_client"
 version = "0.1.0"
 dependencies = [
  "cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,6 +1511,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "point_cloud"
+version = "0.1.0"
+dependencies = [
+ "cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "collision 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "point_viewer 0.1.0",
+ "point_viewer_grpc 0.1.0",
+ "protobuf 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "point_viewer"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tempdir = "0.3.7"
 
 [workspace]
 members = [
+   "point_cloud_client",
    "point_viewer_grpc",
    "point_viewer_grpc_proto_rust",
    "point_viewer_proto_rust",

--- a/point_cloud_client/Cargo.toml
+++ b/point_cloud_client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "point_cloud"
+name = "point_cloud_client"
 version = "0.1.0"
 edition = "2018"
 

--- a/point_cloud_client/Cargo.toml
+++ b/point_cloud_client/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "point_cloud"
+version = "0.1.0"
+edition = "2018"
+
+[[bin]]
+name = "point_cloud_client_test"
+path = "src/bin/test.rs"
+
+[dependencies]
+cgmath = "0.16.0"
+collision = "0.18.0"
+fnv = "1.0.6"
+point_viewer = { path = ".." }
+point_viewer_grpc = { path = "../point_viewer_grpc" }
+protobuf = "2.0.0"
+structopt = "0.2"

--- a/point_cloud_client/src/bin/test.rs
+++ b/point_cloud_client/src/bin/test.rs
@@ -3,7 +3,7 @@
 
 use cgmath::Point3;
 use collision::Aabb3;
-use point_cloud::PointCloudClient;
+use point_cloud_client::PointCloudClient;
 use point_viewer::errors::*;
 use point_viewer::octree::{OctreeFactory, PointCulling, PointLocation};
 use point_viewer::PointData;

--- a/point_cloud_client/src/bin/test.rs
+++ b/point_cloud_client/src/bin/test.rs
@@ -1,0 +1,88 @@
+// This removes clippy warnings regarding redundant StructOpt.
+#![allow(clippy::redundant_closure)]
+
+use cgmath::Point3;
+use collision::Aabb3;
+use point_cloud::PointCloudClient;
+use point_viewer::errors::*;
+use point_viewer::octree::{OctreeFactory, PointCulling, PointLocation};
+use point_viewer::PointData;
+use structopt::StructOpt;
+
+fn point3f64_from_str(s: &str) -> std::result::Result<Point3<f64>, &'static str> {
+    let coords: std::result::Result<Vec<f64>, &'static str> = s
+        .split(|c| c == ' ' || c == ',' || c == ';')
+        .map(|s| s.parse::<f64>().map_err(|_| "Could not parse point."))
+        .collect();
+    let coords = coords?;
+    if coords.len() != 3 {
+        return Err("Wrong number of coordinates.");
+    }
+    Ok(Point3::new(coords[0], coords[1], coords[2]))
+}
+
+#[derive(StructOpt)]
+#[structopt(about = "Simple point_cloud_client test.")]
+struct CommandlineArguments {
+    /// The locations containing the octree data.
+    #[structopt(parse(from_str), raw(required = "true"))]
+    locations: Vec<String>,
+
+    /// The minimum value of the bounding box to be queried.
+    #[structopt(
+        long = "min",
+        default_value = "-500.0 -500.0 -500.0",
+        parse(try_from_str = "point3f64_from_str")
+    )]
+    min: Point3<f64>,
+
+    /// The maximum value of the bounding box to be queried.
+    #[structopt(
+        long = "max",
+        default_value = "500.0 500.0 500.0",
+        parse(try_from_str = "point3f64_from_str")
+    )]
+    max: Point3<f64>,
+
+    /// The maximum number of points to return.
+    #[structopt(long = "num-points", default_value = "50000000")]
+    num_points: usize,
+}
+
+fn main() {
+    let args = CommandlineArguments::from_args();
+    let num_points = args.num_points;
+    let point_cloud_client = PointCloudClient::new(&args.locations, OctreeFactory::new())
+        .expect("Couldn't create octree client.");
+    let point_location = PointLocation {
+        culling: PointCulling::Aabb(Aabb3::new(args.min, args.max)),
+        global_from_local: None,
+    };
+    let mut point_count: usize = 0;
+    let mut print_count: usize = 1;
+    let callback_func = |point_data: PointData| -> Result<()> {
+        point_count += point_data.position.len();
+        if point_count >= print_count * 1_000_000 {
+            print_count += 1;
+            println!("Streamed {}M points", point_count / 1_000_000);
+        }
+        if point_count >= num_points {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                format!("Maximum number of {} points reached.", num_points),
+            )
+            .into());
+        }
+        Ok(())
+    };
+    match point_cloud_client.for_each_point_data(&point_location, callback_func) {
+        Ok(_) => (),
+        Err(e) => match e.kind() {
+            ErrorKind::Io(ref e) if e.kind() == std::io::ErrorKind::Interrupted => (),
+            _ => {
+                println!("Encountered error:\n{}", e);
+                std::process::exit(1);
+            }
+        },
+    }
+}

--- a/point_cloud_client/src/lib.rs
+++ b/point_cloud_client/src/lib.rs
@@ -1,0 +1,39 @@
+use point_viewer::errors::*;
+use point_viewer::octree::{
+    BatchIterator, Octree, OctreeFactory, PointLocation, NUM_POINTS_PER_BATCH,
+};
+use point_viewer::PointData;
+
+pub struct PointCloudClient {
+    octrees: Vec<Octree>,
+    pub num_points_per_batch: usize,
+}
+
+impl PointCloudClient {
+    pub fn new(locations: &[String], octree_factory: OctreeFactory) -> Result<Self> {
+        let octrees: Result<Vec<Octree>> = locations
+            .iter()
+            .map(|location| {
+                octree_factory
+                    .generate_octree(location)
+                    .map(|octree| *octree)
+            })
+            .collect();
+        octrees.map(|octrees| PointCloudClient {
+            octrees,
+            num_points_per_batch: NUM_POINTS_PER_BATCH,
+        })
+    }
+
+    pub fn for_each_point_data<F>(&self, point_location: &PointLocation, mut func: F) -> Result<()>
+    where
+        F: FnMut(PointData) -> Result<()>,
+    {
+        for octree in &self.octrees {
+            let mut batch_iterator =
+                BatchIterator::new(octree, point_location, self.num_points_per_batch);
+            batch_iterator.try_for_each_batch(&mut func)?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds a point cloud client capable of dealing with multiple octrees in the same coordinate frame. In addition, a factory is passed which can be extended to handle octrees coming from other sources than local or grpc.