### PR TITLE
Remove unused ecef earth bounding box feature.

### DIFF
--- a/src/bin/build_octree.rs
+++ b/src/bin/build_octree.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use point_viewer::generation::{build_octree_from_file, RootBbox};
+use point_viewer::generation::build_octree_from_file;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -31,16 +31,6 @@ struct CommandlineArguments {
     /// This decides on the number of bits used to encode each node.
     #[structopt(long = "resolution", default_value = "0.001")]
     resolution: f64,
-    // Flag to skip bbox calculation and use a fixed bbox.
-    // The fixed bbox is zero-centered and extends 6_400_000 length units in
-    // each direction, so that the octree can cover the whole earth when
-    // using ECEF coordinates.
-    #[structopt(
-        long = "bbox_type",
-        raw(possible_values = "&RootBbox::variants()", case_insensitive = "true"),
-        default_value = "FromData"
-    )]
-    bbox_type: RootBbox,
 
     /// The number of threads used to shard octree building. Set this as high as possible for SSDs.
     #[structopt(long = "num_threads", default_value = "10")]
@@ -50,11 +40,5 @@ struct CommandlineArguments {
 fn main() {
     let args = CommandlineArguments::from_args();
     let pool = scoped_pool::Pool::new(args.num_threads);
-    build_octree_from_file(
-        &pool,
-        args.output_directory,
-        args.resolution,
-        args.input,
-        args.bbox_type,
-    );
+    build_octree_from_file(&pool, args.output_directory, args.resolution, args.input);
 }


### PR DESCRIPTION
PR #240 added the option to fix the bounding box of an octree, which was never used. This PR reverts these changes, which leads to tight bounding boxes for all octrees again, so we have the option to query this bounding box quickly in the point cloud client, see also PR #270.