### PR TITLE
Xrays with local transforms.

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use cgmath::{
-    BaseFloat, EuclideanSpace, InnerSpace, Point3, Quaternion, Rotation, Vector2, Vector3,
+    BaseFloat, Decomposed, EuclideanSpace, InnerSpace, Point3, Quaternion, Rotation, Vector2,
+    Vector3,
 };
 use collision::{Aabb, Aabb3};
 use num_traits::identities::One;
@@ -146,6 +147,16 @@ impl<'a, S: BaseFloat> Mul<&'a Vector3<S>> for &'a Isometry3<S> {
     type Output = Vector3<S>;
     fn mul(self, _rhs: &'a Vector3<S>) -> Vector3<S> {
         self.rotation * _rhs + self.translation
+    }
+}
+
+impl<S: BaseFloat> Into<Decomposed<Vector3<S>, Quaternion<S>>> for Isometry3<S> {
+    fn into(self) -> Decomposed<Vector3<S>, Quaternion<S>> {
+        Decomposed {
+            scale: S::one(),
+            rot: self.rotation,
+            disp: self.translation,
+        }
     }
 }
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -160,6 +160,12 @@ impl<S: BaseFloat> Into<Decomposed<Vector3<S>, Quaternion<S>>> for Isometry3<S> 
     }
 }
 
+impl<S: BaseFloat> From<Decomposed<Vector3<S>, Quaternion<S>>> for Isometry3<S> {
+    fn from(decomposed: Decomposed<Vector3<S>, Quaternion<S>>) -> Self {
+        Self::new(decomposed.rot, decomposed.disp)
+    }
+}
+
 impl<S: BaseFloat> Isometry3<S> {
     pub fn new(rotation: Quaternion<S>, translation: Vector3<S>) -> Self {
         Isometry3 {

--- a/xray/src/bin/build_xray_quadtree.rs
+++ b/xray/src/bin/build_xray_quadtree.rs
@@ -1,9 +1,17 @@
 use point_viewer::octree::OctreeFactory;
 use point_viewer_grpc::octree_from_grpc_address;
-use xray::build_quadtree::{parse_arguments, point_cloud_client, run};
+use xray::build_quadtree::{parse_arguments, point_cloud_client, run, Extension};
+
+struct NullExtension;
+
+impl Extension for NullExtension {
+    fn pre_init<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b> {
+        app
+    }
+}
 
 pub fn main() {
-    let args = parse_arguments();
+    let args = parse_arguments::<NullExtension>();
     let octree_factory = OctreeFactory::new().register("grpc://", octree_from_grpc_address);
     let point_cloud_client = point_cloud_client(&args, octree_factory);
     run(&args, &point_cloud_client, None);

--- a/xray/src/bin/build_xray_quadtree.rs
+++ b/xray/src/bin/build_xray_quadtree.rs
@@ -4,5 +4,5 @@ use xray::build_quadtree::run;
 
 pub fn main() {
     let octree_factory = OctreeFactory::new().register("grpc://", octree_from_grpc_address);
-    run(octree_factory);
+    run(octree_factory, None);
 }

--- a/xray/src/bin/build_xray_quadtree.rs
+++ b/xray/src/bin/build_xray_quadtree.rs
@@ -1,8 +1,10 @@
 use point_viewer::octree::OctreeFactory;
 use point_viewer_grpc::octree_from_grpc_address;
-use xray::build_quadtree::run;
+use xray::build_quadtree::{parse_arguments, point_cloud_client, run};
 
 pub fn main() {
+    let args = parse_arguments();
     let octree_factory = OctreeFactory::new().register("grpc://", octree_from_grpc_address);
-    run(octree_factory, None);
+    let point_cloud_client = point_cloud_client(&args, octree_factory);
+    run(&args, &point_cloud_client, None);
 }

--- a/xray/src/bin/build_xray_tile.rs
+++ b/xray/src/bin/build_xray_tile.rs
@@ -1,4 +1,4 @@
-use cgmath::{Point2, Point3};
+use cgmath::{Point2, Point3, Vector2};
 use clap::value_t;
 use collision::{Aabb, Aabb2, Aabb3};
 use point_cloud_client::PointCloudClient;
@@ -120,8 +120,7 @@ fn run(
         &None,
         &bbox3,
         output_filename,
-        image_width,
-        image_height,
+        Vector2::new(image_width, image_height),
         coloring_strategy_kind.new_strategy(),
         tile_background_color,
     ) {

--- a/xray/src/bin/build_xray_tile.rs
+++ b/xray/src/bin/build_xray_tile.rs
@@ -117,6 +117,7 @@ fn run(
     let image_height = (bbox2.dim().y / resolution).ceil() as u32;
     if !xray_from_points(
         &point_cloud_client,
+        &None,
         &bbox3,
         output_filename,
         image_width,

--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -136,6 +136,7 @@ pub fn run(octree_factory: OctreeFactory) {
     build_xray_quadtree(
         &pool,
         &point_cloud_client,
+        &None,
         output_directory,
         resolution,
         tile_size,

--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -1,10 +1,11 @@
 use crate::generation::{
     build_xray_quadtree, ColoringStrategyArgument, ColoringStrategyKind,
-    TileBackgroundColorArgument,
+    Tile, TileBackgroundColorArgument,
 };
 use clap::value_t;
 use point_cloud_client::PointCloudClient;
 use point_viewer::color::{TRANSPARENT, WHITE};
+use point_viewer::math::Isometry3;
 use point_viewer::octree::OctreeFactory;
 use scoped_pool::Pool;
 use std::path::Path;
@@ -76,7 +77,7 @@ fn parse_arguments() -> clap::ArgMatches<'static> {
         .get_matches()
 }
 
-pub fn run(octree_factory: OctreeFactory) {
+pub fn run(octree_factory: OctreeFactory, global_from_local: Option<Isometry3<f64>>) {
     let args = parse_arguments();
     let resolution = args
         .value_of("resolution")
@@ -136,10 +137,9 @@ pub fn run(octree_factory: OctreeFactory) {
     build_xray_quadtree(
         &pool,
         &point_cloud_client,
-        &None,
+        &global_from_local,
         output_directory,
-        resolution,
-        tile_size,
+        &Tile{size_px: tile_size, resolution},
         &coloring_strategy_kind,
         tile_background_color,
     )

--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -10,8 +10,12 @@ use point_viewer::octree::OctreeFactory;
 use scoped_pool::Pool;
 use std::path::Path;
 
-pub fn parse_arguments() -> clap::ArgMatches<'static> {
-    clap::App::new("build_xray_quadtree")
+pub trait Extension {
+    fn pre_init<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b>;
+}
+
+pub fn parse_arguments<T: Extension>() -> clap::ArgMatches<'static> {
+    let mut app = clap::App::new("build_xray_quadtree")
         .version("1.0")
         .author("Holger H. Rapp <hrapp@lyft.com>")
         .args(&[
@@ -73,8 +77,9 @@ pub fn parse_arguments() -> clap::ArgMatches<'static> {
                 .takes_value(true)
                 .possible_values(&TileBackgroundColorArgument::variants())
                 .default_value("white"),
-        ])
-        .get_matches()
+        ]);
+    app = T::pre_init(app);
+    app.get_matches()
 }
 
 pub fn point_cloud_client(

--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -1,6 +1,6 @@
 use crate::generation::{
-    build_xray_quadtree, ColoringStrategyArgument, ColoringStrategyKind,
-    Tile, TileBackgroundColorArgument,
+    build_xray_quadtree, ColoringStrategyArgument, ColoringStrategyKind, Tile,
+    TileBackgroundColorArgument,
 };
 use clap::value_t;
 use point_cloud_client::PointCloudClient;
@@ -10,7 +10,7 @@ use point_viewer::octree::OctreeFactory;
 use scoped_pool::Pool;
 use std::path::Path;
 
-fn parse_arguments() -> clap::ArgMatches<'static> {
+pub fn parse_arguments() -> clap::ArgMatches<'static> {
     clap::App::new("build_xray_quadtree")
         .version("1.0")
         .author("Holger H. Rapp <hrapp@lyft.com>")
@@ -77,8 +77,23 @@ fn parse_arguments() -> clap::ArgMatches<'static> {
         .get_matches()
 }
 
-pub fn run(octree_factory: OctreeFactory, global_from_local: Option<Isometry3<f64>>) {
-    let args = parse_arguments();
+pub fn point_cloud_client(
+    args: &clap::ArgMatches<'static>,
+    octree_factory: OctreeFactory,
+) -> PointCloudClient {
+    let octree_locations = args
+        .values_of("octree_locations")
+        .unwrap()
+        .map(String::from)
+        .collect::<Vec<_>>();
+    PointCloudClient::new(&octree_locations, octree_factory).expect("Could not open octree.")
+}
+
+pub fn run(
+    args: &clap::ArgMatches<'static>,
+    point_cloud_client: &PointCloudClient,
+    global_from_local: Option<Isometry3<f64>>,
+) {
     let resolution = args
         .value_of("resolution")
         .unwrap()
@@ -124,22 +139,18 @@ pub fn run(octree_factory: OctreeFactory, global_from_local: Option<Isometry3<f6
         }
     };
 
-    let octree_locations = args
-        .values_of("octree_locations")
-        .unwrap()
-        .map(String::from)
-        .collect::<Vec<_>>();
     let output_directory = Path::new(args.value_of("output_directory").unwrap());
 
     let pool = Pool::new(num_threads);
-    let point_cloud_client =
-        PointCloudClient::new(&octree_locations, octree_factory).expect("Could not open octree.");
     build_xray_quadtree(
         &pool,
-        &point_cloud_client,
+        point_cloud_client,
         &global_from_local,
         output_directory,
-        &Tile{size_px: tile_size, resolution},
+        &Tile {
+            size_px: tile_size,
+            resolution,
+        },
         &coloring_strategy_kind,
         tile_background_color,
     )

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -527,9 +527,11 @@ pub fn build_xray_quadtree(
 
     let bounding_box = match global_from_local {
         Some(global_from_local) => {
-            let decomposed: Decomposed<Vector3<f64>, Quaternion<f64>> =
-                global_from_local.clone().into();
-            point_cloud_client.bounding_box().transform(&decomposed)
+            let local_from_global: Decomposed<Vector3<f64>, Quaternion<f64>> =
+                global_from_local.inverse().into();
+            point_cloud_client
+                .bounding_box()
+                .transform(&local_from_global)
         }
         None => *point_cloud_client.bounding_box(),
     };


### PR DESCRIPTION
This PR adds the ability to pass a transform to `build_xray_quadtree`, so all processed points are treated as points in a local axis aligned bounding box. This is important, if the octree points are e.g. in ECEF coordinates, since xray generation expects a local, gravity aligned coordinate frame.