### PR TITLE
Extend camera to inject local from global transform.

### DIFF
--- a/sdl_viewer/src/bin/sdl_viewer.rs
+++ b/sdl_viewer/src/bin/sdl_viewer.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use cgmath::Matrix4;
-use point_viewer::octree::OctreeFactory;
+use point_viewer::math::Isometry3;
+use point_viewer::octree::{Octree, OctreeFactory};
 use point_viewer_grpc::octree_from_grpc_address;
 use sdl_viewer::{opengl, run, Extension};
 use std::rc::Rc;
@@ -27,6 +28,10 @@ impl Extension for NullExtension {
 
     fn new(_: &clap::ArgMatches, _: Rc<opengl::Gl>) -> Self {
         Self
+    }
+
+    fn global_from_local(_: &clap::ArgMatches, _: &Octree) -> Option<Isometry3<f64>> {
+        None
     }
 
     fn camera_changed(&mut self, _: &Matrix4<f64>) {}

--- a/sdl_viewer/src/bin/sdl_viewer.rs
+++ b/sdl_viewer/src/bin/sdl_viewer.rs
@@ -30,7 +30,7 @@ impl Extension for NullExtension {
         Self
     }
 
-    fn global_from_local(_: &clap::ArgMatches, _: &Octree) -> Option<Isometry3<f64>> {
+    fn local_from_global(_: &clap::ArgMatches, _: &Octree) -> Option<Isometry3<f64>> {
         None
     }
 

--- a/sdl_viewer/src/camera.rs
+++ b/sdl_viewer/src/camera.rs
@@ -17,6 +17,7 @@ use cgmath::{
     Decomposed, Deg, InnerSpace, Matrix4, One, PerspectiveFov, Quaternion, Rad, Rotation,
     Rotation3, Transform, Vector3, Zero,
 };
+use point_viewer::math::Isometry3;
 use serde_derive::{Deserialize, Serialize};
 use std::f64;
 use time;
@@ -89,7 +90,16 @@ const FAR_PLANE: f32 = 10000.;
 const NEAR_PLANE: f32 = 0.1;
 
 impl Camera {
-    pub fn new(gl: &opengl::Gl, width: i32, height: i32) -> Self {
+    pub fn new(
+        gl: &opengl::Gl,
+        width: i32,
+        height: i32,
+        global_from_local: Option<Isometry3<f64>>,
+    ) -> Self {
+        let mut transform = Isometry3::new(Quaternion::one(), Vector3::new(0., 0., 150.));
+        if global_from_local.is_some() {
+            transform = global_from_local.unwrap() * transform;
+        }
         let mut camera = Camera {
             movement_speed: 10.,
             moving_backward: false,
@@ -108,11 +118,7 @@ impl Camera {
             pan: Vector3::zero(),
             rotation_speed: RotationAngle::zero(),
             delta_rotation: RotationAngle::zero(),
-            transform: Decomposed {
-                scale: 1.,
-                rot: Quaternion::one(),
-                disp: Vector3::new(0., 0., 150.),
-            },
+            transform: transform.into(),
 
             // These will be set by set_size().
             projection_matrix: One::one(),

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -300,7 +300,7 @@ fn load_camera(index: usize, pose_path: &Option<PathBuf>, camera: &mut Camera) {
 pub trait Extension {
     fn pre_init<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b>;
     fn new(matches: &clap::ArgMatches, opengl: Rc<opengl::Gl>) -> Self;
-    fn global_from_local(matches: &clap::ArgMatches, octree: &Octree) -> Option<Isometry3<f64>>;
+    fn local_from_global(matches: &clap::ArgMatches, octree: &Octree) -> Option<Isometry3<f64>>;
     fn camera_changed(&mut self, transform: &Matrix4<f64>);
     fn draw(&mut self);
 }
@@ -466,10 +466,10 @@ pub fn run<T: Extension>(octree_factory: OctreeFactory) {
     }));
 
     let mut extension = T::new(&matches, Rc::clone(&gl));
-    let global_from_local = T::global_from_local(&matches, &octree);
+    let local_from_global = T::local_from_global(&matches, &octree);
 
     let mut renderer = PointCloudRenderer::new(max_nodes_in_memory, Rc::clone(&gl), octree);
-    let mut camera = Camera::new(&gl, WINDOW_WIDTH, WINDOW_HEIGHT, global_from_local);
+    let mut camera = Camera::new(&gl, WINDOW_WIDTH, WINDOW_HEIGHT, local_from_global);
 
     let mut events = ctx.event_pump().unwrap();
     let mut last_frame_time = time::PreciseTime::now();

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -42,7 +42,8 @@ use crate::camera::Camera;
 use crate::node_drawer::{NodeDrawer, NodeViewContainer};
 use cgmath::{Matrix4, SquareMatrix};
 use point_viewer::color::YELLOW;
-use point_viewer::octree::{self, OctreeFactory};
+use point_viewer::math::Isometry3;
+use point_viewer::octree::{self, Octree, OctreeFactory};
 use sdl2::event::{Event, WindowEvent};
 use sdl2::keyboard::{Scancode, LCTRLMOD, LSHIFTMOD, RCTRLMOD, RSHIFTMOD};
 use sdl2::video::GLProfile;
@@ -299,6 +300,7 @@ fn load_camera(index: usize, pose_path: &Option<PathBuf>, camera: &mut Camera) {
 pub trait Extension {
     fn pre_init<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b>;
     fn new(matches: &clap::ArgMatches, opengl: Rc<opengl::Gl>) -> Self;
+    fn global_from_local(matches: &clap::ArgMatches, octree: &Octree) -> Option<Isometry3<f64>>;
     fn camera_changed(&mut self, transform: &Matrix4<f64>);
     fn draw(&mut self);
 }
@@ -382,7 +384,7 @@ pub fn run<T: Extension>(octree_factory: OctreeFactory) {
     let max_nodes_in_memory = limit_cache_size_mb * 5;
 
     // If no octree was generated create an FromDisc loader
-    let octree = Arc::from(
+    let octree: Arc<Box<Octree>> = Arc::from(
         octree_factory
             .generate_octree(octree_argument)
             .expect("Valid path expected"),
@@ -464,9 +466,10 @@ pub fn run<T: Extension>(octree_factory: OctreeFactory) {
     }));
 
     let mut extension = T::new(&matches, Rc::clone(&gl));
+    let global_from_local = T::global_from_local(&matches, &octree);
 
     let mut renderer = PointCloudRenderer::new(max_nodes_in_memory, Rc::clone(&gl), octree);
-    let mut camera = Camera::new(&gl, WINDOW_WIDTH, WINDOW_HEIGHT);
+    let mut camera = Camera::new(&gl, WINDOW_WIDTH, WINDOW_HEIGHT, global_from_local);
 
     let mut events = ctx.event_pump().unwrap();
     let mut last_frame_time = time::PreciseTime::now();


### PR DESCRIPTION
This is based on https://github.com/googlecartographer/point_cloud_viewer/tree/nnmm/ecef_camera, but generalizes the concept, so no proto is needed.