### PR TITLE
Splitted batch iterator functionality

### DIFF
--- a/point_cloud_client/src/lib.rs
+++ b/point_cloud_client/src/lib.rs
@@ -1,8 +1,6 @@
 use collision::{Aabb, Aabb3, Union};
 use point_viewer::errors::*;
-use point_viewer::octree::{
-    BatchIterator, Octree, OctreeFactory, PointQuery, NUM_POINTS_PER_BATCH,
-};
+use point_viewer::octree::{self, Octree, OctreeFactory, PointQuery, NUM_POINTS_PER_BATCH};
 use point_viewer::PointData;
 
 pub struct PointCloudClient {
@@ -44,9 +42,12 @@ impl PointCloudClient {
         F: FnMut(PointData) -> Result<()>,
     {
         for octree in &self.octrees {
-            let mut batch_iterator =
-                BatchIterator::new(octree, point_location, self.num_points_per_batch);
-            batch_iterator.try_for_each_batch(&mut func)?;
+            octree::try_for_each_point_batch(
+                octree,
+                point_location,
+                self.num_points_per_batch,
+                &mut func,
+            )?
         }
         Ok(())
     }

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -27,7 +27,7 @@ use grpcio::{
 };
 use point_viewer::errors::*;
 use point_viewer::math::{Isometry3, OrientedBeam};
-use point_viewer::octree::{self, BatchIterator, NodeId, Octree, OctreeFactory, PointQuery};
+use point_viewer::octree::{self, NodeId, Octree, OctreeFactory, PointQuery};
 use point_viewer::{LayerData, PointData};
 use protobuf::Message;
 use std::collections::HashMap;
@@ -329,10 +329,13 @@ impl OctreeService {
                     Ok(())
                 };
 
-                let mut batch_iterator =
-                    BatchIterator::new(&service_data.octree, &query, num_points_per_batch);
-                // TODO(catevita): missing error handling for the thread
-                let _result = batch_iterator.try_for_each_batch(func);
+                // TODO(catevita) missing error handling for the thread
+                let _result = octree::try_for_each_point_batch(
+                    &service_data.octree,
+                    &query,
+                    num_points_per_batch,
+                    func,
+                );
             }
             tx.send((reply, WriteFlags::default())).unwrap();
         });

--- a/src/octree/batch_iterator.rs
+++ b/src/octree/batch_iterator.rs
@@ -157,7 +157,7 @@ pub fn get_point_data_iterator<'a>(
     point_query: &'a PointQuery,
     batch_size: usize,
 ) -> VecDeque<Box<BatchIterator<impl Fn(&Point) -> bool>>> {
-    let local_from_global = point_query.global_from_local.clone().map(|t| t.inverse());
+    let local_from_global = point_query.global_from_local.as_ref().map(|t| t.inverse());
     // nodes iterator: retrieve nodes
     let point_batch_vec: VecDeque<Box<BatchIterator<_>>> = octree
         .nodes_in_location(point_query)

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -45,7 +45,10 @@ mod octree_iterator;
 pub use self::octree_iterator::{FilteredPointsIterator, NodeIdsIterator};
 
 mod batch_iterator;
-pub use self::batch_iterator::{BatchIterator, PointLocation, PointQuery, NUM_POINTS_PER_BATCH};
+pub use self::batch_iterator::{
+    get_point_data_iterator, try_for_each_point_batch, BatchIterator, PointLocation, PointQuery,
+    NUM_POINTS_PER_BATCH,
+};
 
 #[cfg(test)]
 mod octree_test;

--- a/src/octree/octree_test.rs
+++ b/src/octree/octree_test.rs
@@ -3,7 +3,7 @@ mod tests {
     use crate::color::Color;
     use crate::errors::Result;
     use crate::generation::build_octree;
-    use crate::octree::{self, BatchIterator, PointLocation, PointQuery};
+    use crate::octree::{self, PointLocation, PointQuery};
     use crate::{Point, PointData};
     use cgmath::{EuclideanSpace, Point3, Vector3};
     use collision::{Aabb, Aabb3};
@@ -89,14 +89,13 @@ mod tests {
             location: PointLocation::AllPoints(),
             global_from_local: None,
         };
-        let mut batch_iterator = BatchIterator::new(&octree, &location, batch_size);
 
-        let _err_stop = batch_iterator
-            .try_for_each_batch(callback_func)
-            .expect_err("Test error");
+        let _err_stop =
+            octree::try_for_each_point_batch(&octree, &location, batch_size, callback_func)
+                .expect_err("Test error");
 
-        assert_eq!(3, callback_count);
-        assert_eq!(3 * batch_size, delivered_points);
+        assert!(callback_count >= 3);
+        assert!(callback_count * batch_size >= delivered_points);
         assert!(delivered_points as i32 - max_num_points as i32 >= 0);
     }
 
@@ -132,14 +131,13 @@ mod tests {
             location: PointLocation::AllPoints(),
             global_from_local: None,
         };
-        let mut batch_iterator = BatchIterator::new(&octree, &location, batch_size);
 
-        let _err_stop = batch_iterator
-            .try_for_each_batch(callback_func)
-            .expect_err("Test error");
+        let _err_stop =
+            octree::try_for_each_point_batch(&octree, &location, batch_size, callback_func)
+                .expect_err("Test error");
 
-        assert_eq!(3, callback_count);
-        assert_eq!(3 * batch_size, delivered_points);
+        assert!(callback_count >= 3);
+        assert!(callback_count * batch_size >= delivered_points);
         assert!(delivered_points as i32 - max_num_points as i32 >= 0);
     }
 


### PR DESCRIPTION
splitted batch iterator functionality into 
- getting node_ids per octree according to a function e.g. point location
- getting from each node chunks of data
- computing the mut function at the end

this is the pre step that allows finally for a parallelization of the query
