### PR TITLE
Fix cargo caching.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: rust
 
-cache: cargo
+# See https://levans.fr/rust_travis_cache.html
+cache:
+  directories:
+    - /home/travis/.cargo
+
+before_cache:
+  - rm -rf /home/travis/.cargo/registry
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This fixes failing builds caused by enormous cache sizes in travis ci, see also https://levans.fr/rust_travis_cache.html.