### PR TITLE
Add a few attribute types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,15 +63,17 @@ impl AttributeData {
             AttributeData::U8Vec4(data) => data.len(),
         }
     }
+
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
     pub fn dim(&self) -> usize {
         match self {
-            AttributeData::I64(_) => 1,
-            AttributeData::U64(_) => 1,
-            AttributeData::F32(_) => 1,
-            AttributeData::F64(_) => 1,
+            AttributeData::I64(_)
+            | AttributeData::U64(_)
+            | AttributeData::F32(_)
+            | AttributeData::F64(_) => 1,
             AttributeData::F64Vec3(_) => 3,
             AttributeData::U8Vec4(_) => 4,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,10 @@ pub fn attribute_extension(attribute: &str) -> &str {
 /// General field to describe point feature attributes such as color, intensity, ...
 #[derive(Debug, Clone)]
 pub enum AttributeData {
+    I64(Vec<i64>),
+    U64(Vec<u64>),
     F32(Vec<f32>),
+    F64(Vec<f64>),
     F64Vec3(Vec<Vector3<f64>>),
     U8Vec4(Vec<Vector4<u8>>),
 }
@@ -52,7 +55,10 @@ pub enum AttributeData {
 impl AttributeData {
     pub fn len(&self) -> usize {
         match self {
+            AttributeData::I64(data) => data.len(),
+            AttributeData::U64(data) => data.len(),
             AttributeData::F32(data) => data.len(),
+            AttributeData::F64(data) => data.len(),
             AttributeData::F64Vec3(data) => data.len(),
             AttributeData::U8Vec4(data) => data.len(),
         }
@@ -62,7 +68,10 @@ impl AttributeData {
     }
     pub fn dim(&self) -> usize {
         match self {
+            AttributeData::I64(_) => 1,
+            AttributeData::U64(_) => 1,
             AttributeData::F32(_) => 1,
+            AttributeData::F64(_) => 1,
             AttributeData::F64Vec3(_) => 3,
             AttributeData::U8Vec4(_) => 4,
         }

--- a/src/read_write/node_writer.rs
+++ b/src/read_write/node_writer.rs
@@ -78,9 +78,27 @@ pub trait WriteLE {
     fn write_le(&self, writer: &mut DataWriter) -> Result<()>;
 }
 
+impl WriteLE for i64 {
+    fn write_le(&self, writer: &mut DataWriter) -> Result<()> {
+        writer.write_i64::<LittleEndian>(*self)
+    }
+}
+
+impl WriteLE for u64 {
+    fn write_le(&self, writer: &mut DataWriter) -> Result<()> {
+        writer.write_u64::<LittleEndian>(*self)
+    }
+}
+
 impl WriteLE for f32 {
     fn write_le(&self, writer: &mut DataWriter) -> Result<()> {
         writer.write_f32::<LittleEndian>(*self)
+    }
+}
+
+impl WriteLE for f64 {
+    fn write_le(&self, writer: &mut DataWriter) -> Result<()> {
+        writer.write_f64::<LittleEndian>(*self)
     }
 }
 
@@ -129,24 +147,7 @@ impl WriteLE for Color<u8> {
     }
 }
 
-impl WriteLE for Vec<f32> {
-    fn write_le(&self, writer: &mut DataWriter) -> Result<()> {
-        let mut bytes = vec![0; 4 * self.len()];
-        LittleEndian::write_f32_into(self, &mut bytes);
-        writer.write_all(&bytes)
-    }
-}
-
-impl WriteLE for Vec<Vector3<f64>> {
-    fn write_le(&self, writer: &mut DataWriter) -> Result<()> {
-        for elem in self {
-            elem.write_le(writer)?;
-        }
-        Ok(())
-    }
-}
-
-impl WriteLE for Vec<Vector4<u8>> {
+impl<T: WriteLE> WriteLE for Vec<T> {
     fn write_le(&self, writer: &mut DataWriter) -> Result<()> {
         for elem in self {
             elem.write_le(writer)?;
@@ -158,7 +159,10 @@ impl WriteLE for Vec<Vector4<u8>> {
 impl WriteLE for AttributeData {
     fn write_le(&self, writer: &mut DataWriter) -> Result<()> {
         match self {
+            AttributeData::I64(data) => data.write_le(writer),
+            AttributeData::U64(data) => data.write_le(writer),
             AttributeData::F32(data) => data.write_le(writer),
+            AttributeData::F64(data) => data.write_le(writer),
             AttributeData::F64Vec3(data) => data.write_le(writer),
             AttributeData::U8Vec4(data) => data.write_le(writer),
         }
@@ -172,7 +176,10 @@ pub trait WriteLEPos {
 impl WriteLEPos for AttributeData {
     fn write_le_pos(&self, pos: usize, writer: &mut DataWriter) -> Result<()> {
         match self {
+            AttributeData::I64(data) => data[pos].write_le(writer),
+            AttributeData::U64(data) => data[pos].write_le(writer),
             AttributeData::F32(data) => data[pos].write_le(writer),
+            AttributeData::F64(data) => data[pos].write_le(writer),
             AttributeData::F64Vec3(data) => data[pos].write_le(writer),
             AttributeData::U8Vec4(data) => data[pos].write_le(writer),
         }

--- a/src/read_write/ply.rs
+++ b/src/read_write/ply.rs
@@ -454,7 +454,10 @@ impl NodeWriter<PointsBatch> for PlyNodeWriter {
                         (
                             &k[..],
                             match data {
+                                AttributeData::I64(_) => panic!("Can't write i64 attribute to PLY"),
+                                AttributeData::U64(_) => panic!("Can't write u64 attribute to PLY"),
                                 AttributeData::F32(_) => "float",
+                                AttributeData::F64(_) => "double",
                                 AttributeData::F64Vec3(_) => "double",
                                 AttributeData::U8Vec4(_) => "uchar",
                             },


### PR DESCRIPTION
Also adds a generic `WriteLE` impl for `Vec<T>`, or you would need to write two impls per attribute.