### PR TITLE
Fix color writing and compatibility.

### DIFF
--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -286,14 +286,14 @@ impl OctreeService {
                         .collect();
 
                     reply.colors = match p_data.attributes.get(&"color".to_string()) {
-                        Some(AttributeData::U8Vec4(data)) => data
+                        Some(AttributeData::U8Vec3(data)) => data
                             .iter()
                             .map(|p| {
                                 let rgb8: Color<u8> = crate::Color {
                                     red: p.x,
                                     green: p.y,
                                     blue: p.z,
-                                    alpha: p.w,
+                                    alpha: 255,
                                 };
                                 let rgb32: Color<f32> = crate::Color::to_f32(rgb8);
                                 let mut v = point_viewer::proto::Color::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod octree;
 pub mod read_write;
 pub mod s2_geo;
 
-use cgmath::{Vector3, Vector4};
+use cgmath::Vector3;
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
@@ -48,8 +48,8 @@ pub enum AttributeData {
     U64(Vec<u64>),
     F32(Vec<f32>),
     F64(Vec<f64>),
+    U8Vec3(Vec<Vector3<u8>>),
     F64Vec3(Vec<Vector3<f64>>),
-    U8Vec4(Vec<Vector4<u8>>),
 }
 
 impl AttributeData {
@@ -59,8 +59,8 @@ impl AttributeData {
             AttributeData::U64(data) => data.len(),
             AttributeData::F32(data) => data.len(),
             AttributeData::F64(data) => data.len(),
+            AttributeData::U8Vec3(data) => data.len(),
             AttributeData::F64Vec3(data) => data.len(),
-            AttributeData::U8Vec4(data) => data.len(),
         }
     }
 
@@ -74,8 +74,7 @@ impl AttributeData {
             | AttributeData::U64(_)
             | AttributeData::F32(_)
             | AttributeData::F64(_) => 1,
-            AttributeData::F64Vec3(_) => 3,
-            AttributeData::U8Vec4(_) => 4,
+            AttributeData::U8Vec3(_) | AttributeData::F64Vec3(_) => 3,
         }
     }
 }

--- a/src/octree/batch_iterator.rs
+++ b/src/octree/batch_iterator.rs
@@ -3,7 +3,7 @@ use crate::math::PointCulling;
 use crate::math::{AllPoints, Isometry3, Obb, OrientedBeam};
 use crate::octree::{self, FilteredPointsIterator, Octree};
 use crate::{AttributeData, Point, PointsBatch};
-use cgmath::{Matrix4, Vector3, Vector4};
+use cgmath::{Matrix4, Vector3};
 use collision::Aabb3;
 use crossbeam::deque::{Injector, Worker};
 use std::collections::BTreeMap;
@@ -46,7 +46,7 @@ where
     F: Fn(PointsBatch) -> Result<()>,
 {
     position: Vec<Vector3<f64>>,
-    color: Vec<Vector4<u8>>,
+    color: Vec<Vector3<u8>>,
     intensity: Vec<f32>,
     local_from_global: &'a Option<Isometry3<f64>>,
     func: &'a F,
@@ -77,11 +77,10 @@ where
             None => point.position,
         };
         self.position.push(position);
-        self.color.push(Vector4::new(
+        self.color.push(Vector3::new(
             point.color.red,
             point.color.green,
             point.color.blue,
-            point.color.alpha,
         ));
         if let Some(point_intensity) = point.intensity {
             self.intensity.push(point_intensity);
@@ -97,7 +96,7 @@ where
         let mut attributes = BTreeMap::default();
         attributes.insert(
             "color".to_string(),
-            AttributeData::U8Vec4(self.color.split_off(0)),
+            AttributeData::U8Vec3(self.color.split_off(0)),
         );
         if !self.intensity.is_empty() {
             attributes.insert(

--- a/src/read_write/node_writer.rs
+++ b/src/read_write/node_writer.rs
@@ -15,7 +15,7 @@
 use crate::color::Color;
 use crate::AttributeData;
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
-use cgmath::{Vector3, Vector4};
+use cgmath::Vector3;
 use std::fs::{remove_file, File};
 use std::io::{BufWriter, Result, Seek, SeekFrom, Write};
 use std::path::PathBuf;
@@ -139,22 +139,16 @@ impl WriteLE for Vector3<f64> {
     }
 }
 
-impl WriteLE for Vector4<u8> {
-    fn write_le(&self, writer: &mut DataWriter) -> Result<()> {
-        writer.write_all(&self[..])
-    }
-}
-
 impl WriteLE for Color<u8> {
     fn write_le(&self, writer: &mut DataWriter) -> Result<()> {
         writer.write_u8(self.red)?;
         writer.write_u8(self.green)?;
-        writer.write_u8(self.blue)?;
-        writer.write_u8(self.alpha)
+        writer.write_u8(self.blue)
+        // Alpha is not written on purpose to be compatible with old versions and not waste space.
     }
 }
 
-impl WriteLE for Vec<Vector3<f64>> {
+impl WriteLE for Vec<Vector3<u8>> {
     fn write_le(&self, writer: &mut DataWriter) -> Result<()> {
         for elem in self {
             elem.write_le(writer)?;
@@ -163,7 +157,7 @@ impl WriteLE for Vec<Vector3<f64>> {
     }
 }
 
-impl WriteLE for Vec<Vector4<u8>> {
+impl WriteLE for Vec<Vector3<f64>> {
     fn write_le(&self, writer: &mut DataWriter) -> Result<()> {
         for elem in self {
             elem.write_le(writer)?;
@@ -179,8 +173,8 @@ impl WriteLE for AttributeData {
             AttributeData::U64(data) => data.write_le(writer),
             AttributeData::F32(data) => data.write_le(writer),
             AttributeData::F64(data) => data.write_le(writer),
+            AttributeData::U8Vec3(data) => data.write_le(writer),
             AttributeData::F64Vec3(data) => data.write_le(writer),
-            AttributeData::U8Vec4(data) => data.write_le(writer),
         }
     }
 }
@@ -196,8 +190,8 @@ impl WriteLEPos for AttributeData {
             AttributeData::U64(data) => data[pos].write_le(writer),
             AttributeData::F32(data) => data[pos].write_le(writer),
             AttributeData::F64(data) => data[pos].write_le(writer),
+            AttributeData::U8Vec3(data) => data[pos].write_le(writer),
             AttributeData::F64Vec3(data) => data[pos].write_le(writer),
-            AttributeData::U8Vec4(data) => data[pos].write_le(writer),
         }
     }
 }

--- a/src/read_write/ply.rs
+++ b/src/read_write/ply.rs
@@ -470,8 +470,8 @@ impl NodeWriter<PointsBatch> for PlyNodeWriter {
                                 AttributeData::U64(_) => "ulonglong",
                                 AttributeData::F32(_) => "float",
                                 AttributeData::F64(_) => "double",
+                                AttributeData::U8Vec3(_) => "uchar",
                                 AttributeData::F64Vec3(_) => "double",
-                                AttributeData::U8Vec4(_) => "uchar",
                             },
                             data.dim(),
                         )
@@ -496,7 +496,7 @@ impl NodeWriter<PointsBatch> for PlyNodeWriter {
 impl NodeWriter<Point> for PlyNodeWriter {
     fn write(&mut self, p: &Point) -> io::Result<()> {
         if self.point_count == 0 {
-            let mut attributes = vec![("color", "uchar", 4)];
+            let mut attributes = vec![("color", "uchar", 3)];
             if p.intensity.is_some() {
                 attributes.push(("intensity", "float", 1));
             }

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -303,13 +303,13 @@ impl ColoringStrategy for PointColorColoringStrategy {
             .attributes
             .get("color")
             .expect("Coloring was requested, but point data without color found.");
-        if let AttributeData::U8Vec4(color_vec) = color_attribute {
+        if let AttributeData::U8Vec3(color_vec) = color_attribute {
             for i in 0..color_vec.len() {
                 let clr = Color::<u8> {
                     red: color_vec[i][0],
                     green: color_vec[i][1],
                     blue: color_vec[i][2],
-                    alpha: color_vec[i][3],
+                    alpha: 255,
                 }
                 .to_f32();
                 match self


### PR DESCRIPTION
PR #294 introduced writing of alpha values of colors. Previously we only wrote rgb. Since we also only read rgb, this lead to buggy behavior. This PR unifies reading and writing again to just rgb, so we are compatible with old files.
Also the representation of colors in `AttributeData` is changed to a three-vector.