### PR TITLE
Change interface to not be confused with From trait.

### DIFF
--- a/src/read_write/node_writer.rs
+++ b/src/read_write/node_writer.rs
@@ -278,6 +278,6 @@ impl WriteEncoded for Vec<Vector3<f64>> {
 }
 
 pub trait NodeWriter<P> {
-    fn from(path: impl Into<PathBuf>, codec: Encoding, open_mode: OpenMode) -> Self;
+    fn new(path: impl Into<PathBuf>, codec: Encoding, open_mode: OpenMode) -> Self;
     fn write(&mut self, p: &P) -> Result<()>;
 }

--- a/src/read_write/ply.rs
+++ b/src/read_write/ply.rs
@@ -460,7 +460,7 @@ pub struct PlyNodeWriter {
 }
 
 impl NodeWriter<PointsBatch> for PlyNodeWriter {
-    fn from(filename: impl Into<PathBuf>, encoding: Encoding, open_mode: OpenMode) -> Self {
+    fn new(filename: impl Into<PathBuf>, encoding: Encoding, open_mode: OpenMode) -> Self {
         Self::new(filename, encoding, open_mode)
     }
 
@@ -501,7 +501,7 @@ impl NodeWriter<PointsBatch> for PlyNodeWriter {
 }
 
 impl NodeWriter<Point> for PlyNodeWriter {
-    fn from(filename: impl Into<PathBuf>, encoding: Encoding, open_mode: OpenMode) -> Self {
+    fn new(filename: impl Into<PathBuf>, encoding: Encoding, open_mode: OpenMode) -> Self {
         Self::new(filename, encoding, open_mode)
     }
 

--- a/src/read_write/raw.rs
+++ b/src/read_write/raw.rs
@@ -159,7 +159,7 @@ pub struct RawNodeWriter {
 }
 
 impl NodeWriter<PointsBatch> for RawNodeWriter {
-    fn from(path: impl Into<PathBuf>, encoding: Encoding, open_mode: OpenMode) -> Self {
+    fn new(path: impl Into<PathBuf>, encoding: Encoding, open_mode: OpenMode) -> Self {
         Self::new(path, encoding, open_mode)
     }
 
@@ -185,7 +185,7 @@ impl NodeWriter<PointsBatch> for RawNodeWriter {
 }
 
 impl NodeWriter<Point> for RawNodeWriter {
-    fn from(path: impl Into<PathBuf>, encoding: Encoding, open_mode: OpenMode) -> Self {
+    fn new(path: impl Into<PathBuf>, encoding: Encoding, open_mode: OpenMode) -> Self {
         Self::new(path, encoding, open_mode)
     }
 

--- a/src/read_write/s2.rs
+++ b/src/read_write/s2.rs
@@ -23,7 +23,7 @@ impl<W> NodeWriter<PointsBatch> for S2Splitter<W>
 where
     W: NodeWriter<PointsBatch>,
 {
-    fn from(path: impl Into<PathBuf>, encoding: Encoding, open_mode: OpenMode) -> Self {
+    fn new(path: impl Into<PathBuf>, encoding: Encoding, open_mode: OpenMode) -> Self {
         let writers = LruCache::new(MAX_NUM_NODE_WRITERS);
         let already_opened_writers = HashSet::new();
         let stem = path.into();
@@ -96,7 +96,7 @@ where
                 OpenMode::Truncate
             };
             self.writers
-                .put(key.clone(), W::from(path, self.encoding.clone(), open_mode));
+                .put(key.clone(), W::new(path, self.encoding.clone(), open_mode));
         }
         self.writers.get_mut(&key).unwrap()
     }


### PR DESCRIPTION
With this PR, it is easier to construct `NodeWriter`. Previously, when trying to use `from`, you got an error like
```
   |     let mut s2_writer = S2Splitter::from(out_path, Encoding::Plain, OpenMode::Truncate);
   |                         ^^^^^^^^^^^^^^^^ multiple `from` found
   |
   = note: candidate #1 is defined in an impl of the trait `std::convert::From` for the type `_`
   = note: candidate #2 is defined in an impl of the trait `point_viewer::read_write::node_writer::NodeWriter` for the type `point_viewer::read_write::s2::S2Splitter<_>`
```
