### PR TITLE
Use std::slice::from_ref to prettify code

### DIFF
--- a/point_viewer_grpc/src/bin/octree_benchmark.rs
+++ b/point_viewer_grpc/src/bin/octree_benchmark.rs
@@ -88,22 +88,25 @@ fn server_benchmark(
     num_threads: usize,
     buffer_size: usize,
 ) {
-    let octree: [Octree; 1] = [
-        *octree_from_directory(octree_directory).unwrap_or_else(|_| {
-            panic!(
-                "Could not create octree from '{}'",
-                octree_directory.display()
-            )
-        }),
-    ];
+    let octree: Box<Octree> = octree_from_directory(octree_directory).unwrap_or_else(|_| {
+        panic!(
+            "Could not create octree from '{}'",
+            octree_directory.display()
+        )
+    });
     let mut counter: usize = 0;
     let mut points_streamed_m = 0;
     let all_points = PointQuery {
         location: PointLocation::AllPoints(),
         global_from_local: None,
     };
-    let mut batch_iterator =
-        BatchIterator::new(&octree, &all_points, BATCH_SIZE, num_threads, buffer_size);
+    let mut batch_iterator = BatchIterator::new(
+        std::slice::from_ref(&octree),
+        &all_points,
+        BATCH_SIZE,
+        num_threads,
+        buffer_size,
+    );
     println!("Server benchmark:");
     let _result = batch_iterator.try_for_each_batch(move |points_batch| {
         counter += points_batch.position.len();

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -37,7 +37,7 @@ use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 
 struct OctreeServiceData {
-    octree: [Octree; 1], // caveat: only one octree in this slice
+    octree: Box<Octree>,
     meta: point_viewer::proto::Meta,
 }
 
@@ -95,7 +95,7 @@ impl proto_grpc::Octree for OctreeService {
             Ok(node_id) => node_id,
             Err(e) => return send_fail(&ctx, sink, e.to_string()),
         };
-        let node_data = match service_data.octree[0].get_node_data(&node_id) {
+        let node_data = match service_data.octree.get_node_data(&node_id) {
             Ok(data) => data,
             Err(e) => return send_fail(&ctx, sink, e.to_string()),
         };
@@ -332,7 +332,7 @@ impl OctreeService {
                 };
 
                 let mut batch_iterator = BatchIterator::new(
-                    &service_data.octree,
+                    std::slice::from_ref(&service_data.octree),
                     &query,
                     num_points_per_batch,
                     num_cpus::get() - 1,
@@ -356,14 +356,11 @@ impl OctreeService {
         if let Some(service_data) = self.data_cache.read().unwrap().get(octree_id) {
             return Ok(Arc::clone(service_data));
         };
-        let octree_slice: [Octree; 1] = [*self
+        let octree = self
             .factory
-            .generate_octree(self.location.join(&octree_id).to_string_lossy())?];
-        let meta = octree_slice[0].to_meta_proto();
-        let service_data = Arc::new(OctreeServiceData {
-            octree: octree_slice,
-            meta,
-        });
+            .generate_octree(self.location.join(&octree_id).to_string_lossy())?;
+        let meta = octree.to_meta_proto();
+        let service_data = Arc::new(OctreeServiceData { octree, meta });
         self.data_cache
             .write()
             .unwrap()

--- a/src/octree/octree_test.rs
+++ b/src/octree/octree_test.rs
@@ -2,7 +2,7 @@
 mod tests {
     use crate::color::Color;
     use crate::errors::Result;
-    use crate::octree::{self, build_octree, BatchIterator, Octree, PointLocation, PointQuery};
+    use crate::octree::{self, build_octree, BatchIterator, PointLocation, PointQuery};
     use crate::{Point, PointsBatch};
     use cgmath::{EuclideanSpace, Point3, Vector3};
     use collision::{Aabb, Aabb3};
@@ -87,13 +87,13 @@ mod tests {
         };
 
         // octree and iterator
-        let octree_vec: [Octree; 1] = [*build_test_octree()];
+        let octree = build_test_octree();
         let location = PointQuery {
             location: PointLocation::AllPoints(),
             global_from_local: None,
         };
         let mut batch_iterator = BatchIterator::new(
-            &octree_vec,
+            std::slice::from_ref(&octree),
             &location,
             batch_size,
             std::cmp::max(1, num_cpus::get() - 1),
@@ -143,13 +143,14 @@ mod tests {
             Ok(())
         };
         // octree and iterator
-        let octree_vec: [Octree; 1] = [*build_test_octree()];
+        let octree = build_test_octree();
         let location = PointQuery {
             location: PointLocation::AllPoints(),
             global_from_local: None,
         };
 
-        let mut batch_iterator = BatchIterator::new(&octree_vec, &location, batch_size, 2, 2);
+        let mut batch_iterator =
+            BatchIterator::new(std::slice::from_ref(&octree), &location, batch_size, 2, 2);
 
         let _err_stop = batch_iterator
             .try_for_each_batch(callback_func)
@@ -187,13 +188,13 @@ mod tests {
         };
 
         // octree and iterator
-        let octree_vec: [Octree; 1] = [*build_big_test_octree()];
+        let octree = build_big_test_octree();
         let location = PointQuery {
             location: PointLocation::AllPoints(),
             global_from_local: None,
         };
         let mut batch_iterator = BatchIterator::new(
-            &octree_vec,
+            std::slice::from_ref(&octree),
             &location,
             batch_size,
             std::cmp::max(1, num_cpus::get() - 1),


### PR DESCRIPTION
This is a handy function that I think all of us overlooked when we made the BatchIterator accept `&[Octree]`: https://doc.rust-lang.org/std/slice/fn.from_ref.html