### PR TITLE
Moving window texture module in sdl_viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,7 +2183,6 @@ dependencies = [
 name = "sdl_viewer"
 version = "0.1.0"
 dependencies = [
- "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgmath 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "collision 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gif 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jpeg-decoder 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,6 +1584,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "point_cloud_client"
 version = "0.1.0"
 dependencies = [
@@ -2156,12 +2183,15 @@ dependencies = [
 name = "sdl_viewer"
 version = "0.1.0"
 dependencies = [
+ "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgmath 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "collision 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "point_viewer 0.1.0",
  "point_viewer_grpc 0.1.0",
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2443,6 +2473,17 @@ dependencies = [
 [[package]]
 name = "tiff"
 version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tiff"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3180,6 +3221,7 @@ dependencies = [
 "checksum hyper-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ffb1bd5e518d3065840ab315dbbf44e4420e5f7d80e2cb93fa6ffffc50522378"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum image 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44665b4395d1844c96e7dc8ed5754782a1cdfd9ef458a80bbe45702681450504"
+"checksum image 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ee0665404aa0f2ad154021777b785878b0e5b1c1da030455abc3d9ed257c2c67"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
@@ -3253,6 +3295,7 @@ dependencies = [
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a6a0dc3910bc8db877ffed8e457763b317cf880df4ae19109b9f77d277cf6e0"
 "checksum png 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f54b9600d584d3b8a739e1662a595fab051329eff43f20e7d8cc22872962145b"
+"checksum png 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8422b27bb2c013dd97b9aef69e161ce262236f49aaf46a0489011c8ff0264602"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8aefcec9f142b524d98fc81d07827743be89dd6586a1ba6ab21fa66a500b3fa5"
@@ -3344,6 +3387,7 @@ dependencies = [
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum tiff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1e4834f28a0330cb9f3f2c87d2649dca723cb33802e2bdcf18da32759fbec7ce"
+"checksum tiff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b7c2cfc4742bd8a32f2e614339dd8ce30dbcf676bb262bd63a2327bc5df57d"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"

--- a/sdl_viewer/Cargo.toml
+++ b/sdl_viewer/Cargo.toml
@@ -22,7 +22,6 @@ edition = "2018"
 gl_generator = "0.13.0"
 
 [dependencies]
-arrayvec = "0.4.11"
 cgmath = "0.17.0"
 clap = "2.33.0"
 collision = "0.20.1"

--- a/sdl_viewer/Cargo.toml
+++ b/sdl_viewer/Cargo.toml
@@ -22,17 +22,20 @@ edition = "2018"
 gl_generator = "0.13.0"
 
 [dependencies]
+arrayvec = "0.4.11"
 cgmath = "0.17.0"
 clap = "2.33.0"
 collision = "0.20.1"
-lru = "0.1.15"
 fnv = "1.0.6"
+image = "0.22.1"
+lru = "0.1.15"
+num-integer = "0.1.41"
 rand = "0.3.15"
 sdl2 = "0.31.0"
-time = "^0.1.35"
-serde_json = "1.0.33"
-serde_derive = "1.0.80"
 serde = "1.0.80"
+serde_derive = "1.0.80"
+serde_json = "1.0.33"
+time = "^0.1.35"
 
 [features]
 static-link = [ "sdl2/static-link", "sdl2/bundled" ]

--- a/sdl_viewer/src/graphic.rs
+++ b/sdl_viewer/src/graphic.rs
@@ -20,8 +20,8 @@ use crate::opengl::{self, Gl};
 use std::rc::Rc;
 use std::str;
 
-pub mod uniform;
 pub mod moving_window_texture;
+pub mod uniform;
 
 pub struct GlProgram {
     pub gl: Rc<Gl>,

--- a/sdl_viewer/src/graphic.rs
+++ b/sdl_viewer/src/graphic.rs
@@ -21,6 +21,7 @@ use std::rc::Rc;
 use std::str;
 
 pub mod uniform;
+pub mod moving_window_texture;
 
 pub struct GlProgram {
     pub gl: Rc<Gl>,

--- a/sdl_viewer/src/graphic/moving_window_texture.rs
+++ b/sdl_viewer/src/graphic/moving_window_texture.rs
@@ -337,7 +337,7 @@ mod tests {
     where
         I: GenericImageView<Pixel = P>,
         J: GenericImageView<Pixel = P>,
-        P: Pixel + Eq + std::fmt::Debug,
+        P: Pixel + Eq,
     {
         assert_eq!(left.bounds(), right.bounds());
         for x in 0..left.width() {
@@ -353,7 +353,7 @@ mod tests {
         let regions = UpdateRegion::new_regions(4, 7, 16, &test_src);
 
         let mut dest = ImageBuffer::from_pixel(16, 16, Rgba::<u8>([0, 0, 0, 0]));
-        for r in regions {
+        for r in &regions {
             dest.copy_from(&r.pixels, r.x as u32, r.y as u32);
         }
         let reference = ImageBuffer::from_fn(16, 16, |x, y| {

--- a/sdl_viewer/src/graphic/moving_window_texture.rs
+++ b/sdl_viewer/src/graphic/moving_window_texture.rs
@@ -274,6 +274,9 @@ where
             for r in regions {
                 let width = i32::try_from(r.pixels.width()).unwrap();
                 let height = i32::try_from(r.pixels.height()).unwrap();
+                if height * width == 0 {
+                    continue;
+                }
                 let image = r.pixels.to_image();
                 self.gl.TexSubImage2D(
                     opengl::TEXTURE_2D,

--- a/sdl_viewer/src/graphic/moving_window_texture.rs
+++ b/sdl_viewer/src/graphic/moving_window_texture.rs
@@ -163,11 +163,11 @@ where
             // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml
             gl.TexImage2D(
                 opengl::TEXTURE_2D,
-                0,
+                0, // level
                 P::INTERNALFORMAT,
-                size,
-                size,
-                0,
+                size, // width
+                size, // height
+                0, // border
                 P::FORMAT,
                 P::DTYPE,
                 pixels.into_raw().as_ptr() as *const c_void,
@@ -308,7 +308,7 @@ where
                 // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage2D.xhtml
                 self.gl.TexSubImage2D(
                     opengl::TEXTURE_2D,
-                    0,
+                    0, // level
                     r.x,
                     r.y,
                     width,

--- a/sdl_viewer/src/graphic/moving_window_texture.rs
+++ b/sdl_viewer/src/graphic/moving_window_texture.rs
@@ -107,8 +107,7 @@ impl<'a, P: Pixel + 'static> UpdateRegion<'a, P> {
 
 impl<P> GlMovingWindowTexture<P>
 where
-    P: TextureFormat,
-    P: 'static,
+    P: TextureFormat + 'static,
     P::Subpixel: 'static + std::fmt::Debug,
 {
     pub fn new(

--- a/sdl_viewer/src/graphic/moving_window_texture.rs
+++ b/sdl_viewer/src/graphic/moving_window_texture.rs
@@ -108,7 +108,7 @@ impl<'a, P: Pixel + 'static> UpdateRegion<'a, P> {
 impl<P> GlMovingWindowTexture<P>
 where
     P: TextureFormat,
-    P: Pixel + 'static,
+    P: 'static,
     P::Subpixel: 'static + std::fmt::Debug,
 {
     pub fn new(

--- a/sdl_viewer/src/graphic/moving_window_texture.rs
+++ b/sdl_viewer/src/graphic/moving_window_texture.rs
@@ -108,7 +108,7 @@ impl<'a, P: Pixel + 'static> UpdateRegion<'a, P> {
 impl<P> GlMovingWindowTexture<P>
 where
     P: TextureFormat,
-    P: Pixel + 'static + std::fmt::Debug,
+    P: Pixel + 'static,
     P::Subpixel: 'static + std::fmt::Debug,
 {
     pub fn new(

--- a/sdl_viewer/src/graphic/moving_window_texture.rs
+++ b/sdl_viewer/src/graphic/moving_window_texture.rs
@@ -1,0 +1,321 @@
+use crate::graphic::uniform::GlUniform;
+use crate::graphic::GlProgram;
+use crate::opengl;
+use crate::opengl::types::{GLint, GLuint};
+use arrayvec::ArrayVec;
+use cgmath::Vector2;
+use image::{GenericImageView, ImageBuffer, LumaA, Pixel, Rgba, SubImage};
+use num_integer::Integer;
+use std::convert::{TryFrom, TryInto};
+use std::ffi::c_void;
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+/// A square texture that functions like a moving window into a larger texture.
+/// Incrementality is achieved by using wraparound indexing and overwriting the
+/// parts that moved off the texture with the newly loaded parts.
+/// See `https://developer.nvidia.com/gpugems/GPUGems2/gpugems2_chapter02.html`,
+/// section 2.4 for an illustration.
+/// Also publishes an `<texture_name>_texture_offset` uniform whose unit is
+/// pixels (not UV coordinates).
+///
+/// I'm told that a more efficient alternative would be to use a PBO (pixel
+/// buffer object), so a future version could use that instead.
+pub struct GlMovingWindowTexture<P: Pixel> {
+    id: GLuint,
+    gl: Rc<opengl::Gl>,
+    size: i32,
+    u_texture_offset: GlUniform<Vector2<i32>>,
+    pixel_type: PhantomData<P>,
+}
+
+/// Specifies the offsets in the destination, as well as the image to be pasted
+/// there.
+struct UpdateRegion<'a, P: Pixel + 'static> {
+    x: i32,
+    y: i32,
+    pixels: SubImage<&'a ImageBuffer<P, Vec<P::Subpixel>>>,
+}
+
+impl<'a, P: Pixel + 'static> UpdateRegion<'a, P> {
+    /// Splits an image with offset into update regions. See
+    /// [`incremental_update()`] for a detailed explanation.
+    ///
+    /// ```text
+    ///     +---+-+
+    ///     | 3 |4|
+    ///     +---+-+
+    ///     |   | |
+    ///     | 1 |2|
+    ///     |   | |
+    ///     +---+-+
+    ///        |
+    ///        V
+    /// +-+-------+---+
+    /// | |       |   |
+    /// |2|       | 1 |
+    /// | |       |   |
+    /// +-+       +---+
+    /// |4|       | 3 |
+    /// +-+-------+---+
+    /// ```
+    pub fn new_regions(
+        xoff: i32,
+        yoff: i32,
+        size: i32,
+        pixels: &'a ImageBuffer<P, Vec<P::Subpixel>>,
+    ) -> [UpdateRegion<'a, P>; 4] {
+        // Do subtractions in signed numbers to avoid overflow
+        let width: i32 = pixels.width().try_into().unwrap();
+        let height: i32 = pixels.height().try_into().unwrap();
+        let width_1_3 = width.min(size - xoff);
+        let width_2_4 = width - width_1_3;
+        let height_3_4 = height.min(size - yoff);
+        let height_1_2 = height - height_3_4;
+        // The image crate likes unsigned ints
+        let width_1_3 = u32::try_from(width_1_3).unwrap();
+        let width_2_4 = u32::try_from(width_2_4).unwrap();
+        let height_3_4 = u32::try_from(height_3_4).unwrap();
+        let height_1_2 = u32::try_from(height_1_2).unwrap();
+        [
+            UpdateRegion {
+                x: xoff,
+                y: yoff,
+                pixels: pixels.view(0, 0, width_1_3, height_1_2),
+            },
+            UpdateRegion {
+                x: 0,
+                y: yoff,
+                pixels: pixels.view(width_1_3, 0, width_2_4, height_1_2),
+            },
+            UpdateRegion {
+                x: xoff,
+                y: 0,
+                pixels: pixels.view(0, height_1_2, width_1_3, height_3_4),
+            },
+            UpdateRegion {
+                x: 0,
+                y: 0,
+                pixels: pixels.view(width_1_3, height_1_2, width_2_4, height_3_4),
+            },
+        ]
+    }
+}
+
+impl<P> GlMovingWindowTexture<P>
+where
+    P: TextureFormat,
+    P: Pixel + 'static + std::fmt::Debug,
+    P::Subpixel: 'static + std::fmt::Debug,
+{
+    pub fn new(
+        program: &GlProgram,
+        gl: Rc<opengl::Gl>,
+        name: &str,
+        size: i32,
+        pixels: ImageBuffer<P, Vec<P::Subpixel>>,
+    ) -> Self {
+        let mut id = 0;
+        unsafe {
+            gl.UseProgram(program.id);
+            let loc =
+                gl.GetUniformLocation(program.id, (name.to_string() + "\0").as_ptr() as *const i8);
+            gl.Uniform1i(loc, 0);
+
+            gl.GenTextures(1, &mut id);
+            gl.BindTexture(opengl::TEXTURE_2D, id);
+
+            // Enable wraparound addressing
+            gl.TexParameteri(
+                opengl::TEXTURE_2D,
+                opengl::TEXTURE_WRAP_S,
+                opengl::REPEAT as i32,
+            );
+            gl.TexParameteri(
+                opengl::TEXTURE_2D,
+                opengl::TEXTURE_WRAP_T,
+                opengl::REPEAT as i32,
+            );
+
+            // Intended for exact pixel fetching, no interpolation needed
+            gl.TexParameteri(
+                opengl::TEXTURE_2D,
+                opengl::TEXTURE_MIN_FILTER,
+                opengl::NEAREST as i32,
+            );
+            gl.TexParameteri(
+                opengl::TEXTURE_2D,
+                opengl::TEXTURE_MAG_FILTER,
+                opengl::NEAREST as i32,
+            );
+            gl.TexImage2D(
+                opengl::TEXTURE_2D,
+                0,
+                P::INTERNALFORMAT,
+                size,
+                size,
+                0,
+                P::FORMAT,
+                P::DTYPE,
+                pixels.into_raw().as_ptr() as *const c_void,
+            );
+        }
+
+        let u_texture_offset = GlUniform::new(
+            &program,
+            &(name.to_string() + "_texture_offset"),
+            Vector2::new(0, 0),
+        );
+
+        GlMovingWindowTexture {
+            id,
+            gl,
+            size,
+            u_texture_offset,
+            pixel_type: PhantomData,
+        }
+    }
+
+    /// Let's say the texture window has moved left and up. The new pixels that
+    /// are now inside the window are passed as a vertical and a horizontal
+    /// strip. Here they are in the texture window:
+    /// ```text
+    /// +-----+------------+
+    /// |#####|############| <- hori_strip
+    /// +-----|------------+
+    /// |#####|            |
+    /// |#####|            |
+    /// |#####|            |
+    /// +-----+------------+
+    ///    ^
+    ///    |
+    ///   vert_strip
+    /// ```
+    ///
+    /// You can see that they are redundant where they overlap. This is not
+    /// handled to keep the code from becoming more complex. Also, either may
+    /// be empty, which is the case for purely horizontal/vertical shifts.
+    ///
+    /// These strips have to be inserted correctly into the OpenGL texture,
+    /// which starts not at 0 but at `texture_offset` because of wrapping indexing.
+    /// Updating that texture from such a strip can typically not be done in one
+    /// step, but requires breaking it into up to four subregions. This is
+    /// because OpenGL textures can be read with wrapping indexing, but not
+    /// written with wrapping indexing, so we need to do it ourselves.
+    /// Let's look at the vertical strip:
+    ///
+    /// ```text
+    /// <- width ->
+    /// +---+-+
+    /// | 3 |4|
+    /// +---+-+
+    /// |   | |  vert_strip
+    /// | 1 |2|
+    /// |   | |
+    /// +---+-+
+    /// ```
+    ///
+    /// Wraparound at the right texture edge causes the split into regions 1/3
+    /// vs 2/4, and wraparound at the upper texture edge causes the split into
+    /// regions 1/2 vs 3/4.
+    /// Here's the texture with the vert_strip placed correctly:
+    ///
+    /// ```text
+    /// <- self.size ->
+    /// +-+-------+---+
+    /// | |       |   |
+    /// |2|       | 1 |
+    /// | |       |   |
+    /// +-+       +---+ <- texture_offset.y
+    /// |4|       | 3 |
+    /// +-+-------+---+
+    ///           ^
+    ///           |
+    ///           xoff
+    /// ```
+    ///
+    /// `xoff` is not equal to `texture_offset.x` if the texture moved right.
+    ///
+    /// The way this is handled is by creating regions as if they always need
+    /// splitting, and skipping empty regions that result from that.
+    pub fn incremental_update(
+        &mut self,
+        delta_x: i32,
+        delta_y: i32,
+        vert_strip: ImageBuffer<P, Vec<P::Subpixel>>,
+        hori_strip: ImageBuffer<P, Vec<P::Subpixel>>,
+    ) {
+        // width/height are always positive, but if the delta is negative, the
+        // start of the new region is actually offset + delta, not offset
+        let xoff = if delta_x > 0 {
+            self.u_texture_offset.value.x
+        } else {
+            (self.u_texture_offset.value.x + delta_x).mod_floor(&self.size)
+        };
+        let yoff = if delta_y > 0 {
+            self.u_texture_offset.value.y
+        } else {
+            (self.u_texture_offset.value.y + delta_y).mod_floor(&self.size)
+        };
+
+        // u_texture_offset.value is always in [0; self.size)
+        let x = (self.u_texture_offset.value.x + delta_x).mod_floor(&self.size);
+        let y = (self.u_texture_offset.value.y + delta_y).mod_floor(&self.size);
+        self.u_texture_offset.value = Vector2::new(x, y);
+
+        let vert_regions = UpdateRegion::new_regions(xoff, y, self.size, &vert_strip);
+        let hori_regions = UpdateRegion::new_regions(x, yoff, self.size, &hori_strip);
+        let regions = ArrayVec::from(vert_regions)
+            .into_iter()
+            .chain(ArrayVec::from(hori_regions));
+
+        unsafe {
+            self.gl.BindTexture(opengl::TEXTURE_2D, self.id);
+            for r in regions {
+                let width = i32::try_from(r.pixels.width()).unwrap();
+                let height = i32::try_from(r.pixels.height()).unwrap();
+                let image = r.pixels.to_image();
+                self.gl.TexSubImage2D(
+                    opengl::TEXTURE_2D,
+                    0,
+                    r.x,
+                    r.y,
+                    width,
+                    height,
+                    P::FORMAT,
+                    P::DTYPE,
+                    image.into_raw().as_ptr() as *const c_void,
+                );
+            }
+        }
+    }
+
+    /// Updates the offset and binds the texture
+    pub fn submit(&mut self) {
+        unsafe {
+            self.u_texture_offset.submit();
+
+            self.gl.ActiveTexture(opengl::TEXTURE0);
+            self.gl.BindTexture(opengl::TEXTURE_2D, self.id);
+        }
+    }
+}
+
+/// Trait to associate pixel formats with OpenGL constants
+pub trait TextureFormat: Pixel {
+    const INTERNALFORMAT: GLint;
+    const FORMAT: GLuint;
+    const DTYPE: GLuint;
+}
+
+impl TextureFormat for LumaA<f32> {
+    const INTERNALFORMAT: GLint = opengl::RG32F as GLint;
+    const FORMAT: GLuint = opengl::RG;
+    const DTYPE: GLuint = opengl::FLOAT;
+}
+
+impl TextureFormat for Rgba<u8> {
+    const INTERNALFORMAT: GLint = opengl::RGBA8 as GLint;
+    const FORMAT: GLuint = opengl::RGBA;
+    const DTYPE: GLuint = opengl::UNSIGNED_BYTE;
+}

--- a/sdl_viewer/src/graphic/moving_window_texture.rs
+++ b/sdl_viewer/src/graphic/moving_window_texture.rs
@@ -329,9 +329,7 @@ where
 
     /// Updates the offset and binds the texture
     pub fn submit(&mut self) {
-        unsafe {
-            self.u_texture_offset.submit();
-        }
+        self.u_texture_offset.submit();
     }
 }
 

--- a/sdl_viewer/src/graphic/uniform.rs
+++ b/sdl_viewer/src/graphic/uniform.rs
@@ -2,6 +2,7 @@ use crate::graphic::GlProgram;
 use crate::opengl;
 use crate::opengl::types::{GLboolean, GLint};
 use cgmath::{Matrix, Matrix4, Vector2, Vector3};
+use std::ffi::CString;
 use std::rc::Rc;
 
 pub trait Uniform {
@@ -65,11 +66,12 @@ pub struct GlUniform<T> {
 impl<T: Uniform> GlUniform<T> {
     pub fn new(program: &GlProgram, name: &str, value: T) -> Self {
         let location;
+        let name_c = CString::new(name).unwrap();
         unsafe {
             program.gl.UseProgram(program.id);
             location = program
                 .gl
-                .GetUniformLocation(program.id, (name.to_string() + "\0").as_ptr() as *const i8);
+                .GetUniformLocation(program.id, name_c.as_ptr() as *const i8);
         }
         GlUniform {
             location,

--- a/sdl_viewer/src/graphic/uniform.rs
+++ b/sdl_viewer/src/graphic/uniform.rs
@@ -69,9 +69,7 @@ impl<T: Uniform> GlUniform<T> {
         let name_c = CString::new(name).unwrap();
         unsafe {
             program.gl.UseProgram(program.id);
-            location = program
-                .gl
-                .GetUniformLocation(program.id, name_c.as_ptr() as *const i8);
+            location = program.gl.GetUniformLocation(program.id, name_c.as_ptr());
         }
         GlUniform {
             location,


### PR DESCRIPTION
A square texture that functions like a moving window into a larger texture. Incrementality is achieved by using wraparound indexing and overwriting the parts that moved off the texture with the newly loaded parts.

Try cargo doc for reading the comments.