### PR TITLE
S2 Meta writing prerequisites

### DIFF
--- a/point_viewer_proto_rust/src/proto.proto
+++ b/point_viewer_proto_rust/src/proto.proto
@@ -115,7 +115,7 @@ message Attribute {
 }
 
 message S2Cell {
-  int64 id = 1;
+  uint64 id = 1;
   int64 num_points = 2;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod errors;
 pub mod math;
 pub mod octree;
 pub mod read_write;
+pub mod s2_cells;
 
 use cgmath::Vector3;
 use std::collections::BTreeMap;
@@ -62,7 +63,7 @@ pub enum AttributeData {
     F64Vec3(Vec<Vector3<f64>>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AttributeDataType {
     U8,
     I64,

--- a/src/read_write/mod.rs
+++ b/src/read_write/mod.rs
@@ -37,7 +37,7 @@ mod raw;
 pub use self::raw::{RawNodeReader, RawNodeWriter};
 
 mod s2;
-pub use self::s2::{s2_cell_to_proto, s2_cloud_to_meta_proto, S2Splitter};
+pub use self::s2::S2Splitter;
 
 use std::io::{BufReader, Read};
 

--- a/src/read_write/s2.rs
+++ b/src/read_write/s2.rs
@@ -132,6 +132,8 @@ where
         self.writers.get_mut(cell_id).unwrap()
     }
 
+    /// Records the list of attributes seen in the first batch, and checks
+    /// that the following batches contain the same attributes.
     fn check_attributes(&mut self, batch: &PointsBatch) -> Result<()> {
         let mut attr_iter = batch
             .attributes

--- a/src/read_write/s2.rs
+++ b/src/read_write/s2.rs
@@ -1,7 +1,8 @@
-use crate::proto;
 use crate::read_write::{Encoding, NodeWriter, OpenMode};
-use crate::{AttributeData, PointsBatch, CURRENT_VERSION};
+use crate::s2_cells::{S2CellMeta, S2Meta};
+use crate::{AttributeData, AttributeDataType, PointsBatch};
 use cgmath::InnerSpace;
+use fnv::FnvHashMap;
 use lru::LruCache;
 use s2::cellid::CellID;
 use s2::point::Point;
@@ -24,6 +25,8 @@ const EARTH_RADIUS_MAX_M: f64 = 6_384_400.0;
 pub struct S2Splitter<W> {
     writers: LruCache<CellID, W>,
     already_opened_writers: HashSet<CellID>,
+    cell_stats: FnvHashMap<CellID, S2CellMeta>,
+    attributes_seen: BTreeMap<String, AttributeDataType>,
     encoding: Encoding,
     open_mode: OpenMode,
     stem: PathBuf,
@@ -37,9 +40,13 @@ where
         let writers = LruCache::new(MAX_NUM_NODE_WRITERS);
         let already_opened_writers = HashSet::new();
         let stem = path.into();
+        let cell_stats = FnvHashMap::default();
+        let attributes_seen = BTreeMap::new();
         S2Splitter {
             writers,
             already_opened_writers,
+            cell_stats,
+            attributes_seen,
             encoding,
             open_mode,
             stem,
@@ -47,6 +54,7 @@ where
     }
 
     fn write(&mut self, points_batch: &PointsBatch) -> Result<()> {
+        self.check_attributes(points_batch)?;
         let mut batches_by_s2_cell = HashMap::new();
         for (i, pos) in points_batch.position.iter().enumerate() {
             let radius = pos.magnitude();
@@ -58,12 +66,15 @@ where
                 return Err(Error::new(ErrorKind::InvalidInput, msg));
             }
             let s2_point = Point::from_coords(pos.x, pos.y, pos.z);
-            let s2_cell_batch = batches_by_s2_cell
-                .entry(CellID::from(s2_point).parent(S2_SPLIT_LEVEL))
-                .or_insert(PointsBatch {
-                    position: Vec::new(),
-                    attributes: BTreeMap::new(),
-                });
+            let s2_cell_id = CellID::from(s2_point).parent(S2_SPLIT_LEVEL);
+            self.cell_stats
+                .entry(s2_cell_id)
+                .or_insert(S2CellMeta { num_points: 0 })
+                .num_points += 1;
+            let s2_cell_batch = batches_by_s2_cell.entry(s2_cell_id).or_insert(PointsBatch {
+                position: Vec::new(),
+                attributes: BTreeMap::new(),
+            });
             s2_cell_batch.position.push(*pos);
             for (in_key, in_data) in &points_batch.attributes {
                 use AttributeData::*;
@@ -120,35 +131,37 @@ where
         }
         self.writers.get_mut(cell_id).unwrap()
     }
-}
 
-pub fn s2_cloud_to_meta_proto(
-    cells: Vec<proto::S2Cell>,
-    attributes: &BTreeMap<String, AttributeData>,
-) -> proto::Meta {
-    let mut meta = proto::Meta::new();
-    meta.set_version(CURRENT_VERSION);
-    let mut s2_meta = proto::S2Meta::new();
-    s2_meta.set_cells(::protobuf::RepeatedField::<proto::S2Cell>::from_vec(cells));
-    let attributes_meta = attributes
-        .iter()
-        .map(|(name, attribute)| {
-            let mut attr_meta = proto::Attribute::new();
-            attr_meta.set_name(name.to_string());
-            attr_meta.set_data_type(attribute.data_type().to_proto());
-            attr_meta
-        })
-        .collect();
-    s2_meta.set_attributes(::protobuf::RepeatedField::<proto::Attribute>::from_vec(
-        attributes_meta,
-    ));
-    meta.set_s2(s2_meta);
-    meta
-}
+    fn check_attributes(&mut self, batch: &PointsBatch) -> Result<()> {
+        let mut attr_iter = batch
+            .attributes
+            .iter()
+            .map(|(name, data)| (name, data.data_type()));
+        if self.attributes_seen.is_empty() {
+            self.attributes_seen
+                .extend(attr_iter.map(|(key, val)| (key.to_owned(), val)));
+            Ok(())
+        } else {
+            attr_iter.try_for_each(|(name, dtype)| {
+                self.attributes_seen
+                    .get(name)
+                    .filter(|seen_dtype| **seen_dtype == dtype)
+                    .ok_or_else(|| {
+                        let msg = format!(
+                            "S2Splitter received incompatible data types for attribute {}",
+                            name
+                        );
+                        Error::new(ErrorKind::InvalidInput, msg)
+                    })?;
+                Ok(())
+            })
+        }
+    }
 
-pub fn s2_cell_to_proto(cell_id: i64, num_points: i64) -> proto::S2Cell {
-    let mut meta = proto::S2Cell::new();
-    meta.set_id(cell_id);
-    meta.set_num_points(num_points);
-    meta
+    pub fn get_meta(self) -> S2Meta {
+        S2Meta {
+            attributes: self.attributes_seen.into_iter().collect(),
+            cells: self.cell_stats,
+        }
+    }
 }

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -1,0 +1,52 @@
+use crate::proto;
+use crate::{AttributeDataType, CURRENT_VERSION};
+use fnv::FnvHashMap;
+use s2::cellid::CellID;
+use std::collections::HashMap;
+use std::convert::TryInto;
+
+#[derive(Copy, Clone)]
+pub struct S2CellMeta {
+    pub num_points: u64,
+}
+
+pub struct S2Meta {
+    pub cells: FnvHashMap<CellID, S2CellMeta>,
+    pub attributes: HashMap<String, AttributeDataType>,
+}
+
+impl S2Meta {
+    pub fn to_proto(&self) -> proto::Meta {
+        let cell_protos = self
+            .cells
+            .iter()
+            .map(|(cell_id, cell_meta)| {
+                let mut meta = proto::S2Cell::new();
+                meta.set_id(cell_id.0);
+                meta.set_num_points(cell_meta.num_points.try_into().unwrap());
+                meta
+            })
+            .collect();
+        let mut meta = proto::Meta::new();
+        meta.set_version(CURRENT_VERSION);
+        let mut s2_meta = proto::S2Meta::new();
+        s2_meta.set_cells(::protobuf::RepeatedField::<proto::S2Cell>::from_vec(
+            cell_protos,
+        ));
+        let attributes_meta = self
+            .attributes
+            .iter()
+            .map(|(name, attribute)| {
+                let mut attr_meta = proto::Attribute::new();
+                attr_meta.set_name(name.to_string());
+                attr_meta.set_data_type(attribute.to_proto());
+                attr_meta
+            })
+            .collect();
+        s2_meta.set_attributes(::protobuf::RepeatedField::<proto::Attribute>::from_vec(
+            attributes_meta,
+        ));
+        meta.set_s2(s2_meta);
+        meta
+    }
+}


### PR DESCRIPTION
* Changed the CellId in the proto to unsigned, since that is what the S2 library uses
* Keep track of attributes & points per node in S2Splitter