### PR TITLE
Don't write header for empty batches.

### DIFF
--- a/src/read_write/ply.rs
+++ b/src/read_write/ply.rs
@@ -465,6 +465,9 @@ impl NodeWriter<PointsBatch> for PlyNodeWriter {
     }
 
     fn write(&mut self, p: &PointsBatch) -> io::Result<()> {
+        if p.position.is_empty() {
+            return Ok(());
+        }
         if self.point_count == 0 {
             self.create_header(
                 &p.attributes


### PR DESCRIPTION
Calling `write` with empty points batches led to creation of multiple headers. This PR fixes this.