### PR TITLE
Increase annoyingly low rotation speed in sdl_viewer

### DIFF
--- a/sdl_viewer/src/camera.rs
+++ b/sdl_viewer/src/camera.rs
@@ -236,7 +236,7 @@ impl Camera {
 
         let elapsed_seconds = elapsed.num_milliseconds() as f64 / 1000.;
 
-        const TURNING_SPEED: Rad<f64> = Rad(0.15);
+        const TURNING_SPEED: Rad<f64> = Rad(0.5);
         if self.turning_left {
             self.rotation_speed.theta += TURNING_SPEED;
         }


### PR DESCRIPTION
This only affects rotating the camera in sdl_viewer with the keyboard, not with the mouse.