### PR TITLE
Implement nodes querying for OrientedBeam.

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -274,12 +274,12 @@ impl<S: BaseFloat> From<Aabb3<S>> for Obb<S> {
 impl<S: BaseFloat> From<&OrientedBeam<S>> for Obb<S> {
     fn from(beam: &OrientedBeam<S>) -> Self {
         let beam_isometry = beam.isometry_inv.inverse();
-        let z_off = S::from(0.5 * (EARTH_RADIUS_MIN_M + EARTH_RADIUS_MAX_M)).unwrap()
-            - beam_isometry.translation.magnitude();
+        let earth_radius_mean = S::from(0.5 * (EARTH_RADIUS_MIN_M + EARTH_RADIUS_MAX_M)).unwrap();
+        let z_off = earth_radius_mean - beam_isometry.translation.magnitude();
         let pt_off = Point3::new(S::zero(), S::zero(), z_off);
         let translation = beam_isometry.rotation.rotate_point(pt_off) + beam_isometry.translation;
         let isometry = Isometry3::new(beam_isometry.rotation, translation.to_vec());
-        let z_half_extent = S::from(0.5 * (EARTH_RADIUS_MAX_M - EARTH_RADIUS_MIN_M)).unwrap();
+        let z_half_extent = S::from(EARTH_RADIUS_MAX_M).unwrap() - earth_radius_mean;
         let half_extent = Vector3::new(beam.half_extent.x, beam.half_extent.y, z_half_extent);
         Self::new(isometry, half_extent)
     }

--- a/src/math.rs
+++ b/src/math.rs
@@ -272,6 +272,8 @@ impl<S: BaseFloat> From<Aabb3<S>> for Obb<S> {
     }
 }
 
+/// Creates an object oriented box by intersecting the oriented beam with the minimum and maximum
+/// earth radius. The OBB has the same orientation and extents as the beam.
 impl<S: BaseFloat> From<&OrientedBeam<S>> for Obb<S> {
     fn from(beam: &OrientedBeam<S>) -> Self {
         let earth_radius_mean = S::from(0.5 * (EARTH_RADIUS_MIN_M + EARTH_RADIUS_MAX_M)).unwrap();

--- a/src/math.rs
+++ b/src/math.rs
@@ -362,7 +362,8 @@ where
     }
 
     fn contains(&self, p: &Point3<S>) -> bool {
-        let Vector3 { x, y, z } = &self.isometry_inv * &p.to_vec();
+        let Point3 { x, y, z } =
+            self.isometry_inv.rotation.rotate_point(*p) + self.isometry_inv.translation;
         x.abs() <= self.half_extent.x
             && y.abs() <= self.half_extent.y
             && z.abs() <= self.half_extent.z
@@ -440,7 +441,8 @@ where
 
     fn contains(&self, p: &Point3<S>) -> bool {
         // What is the point in beam coordinates?
-        let Vector3 { x, y, .. } = &self.isometry_inv * &p.to_vec();
+        let Point3 { x, y, .. } =
+            self.isometry_inv.rotation.rotate_point(*p) + self.isometry_inv.translation;
         x.abs() <= self.half_extent.x && y.abs() <= self.half_extent.y
     }
 

--- a/src/read_write/s2.rs
+++ b/src/read_write/s2.rs
@@ -1,3 +1,4 @@
+use crate::math::{EARTH_RADIUS_MAX_M, EARTH_RADIUS_MIN_M};
 use crate::read_write::{Encoding, NodeWriter, OpenMode};
 use crate::s2_cells::{S2CellMeta, S2Meta};
 use crate::{AttributeData, AttributeDataType, PointsBatch};
@@ -15,12 +16,6 @@ use std::path::PathBuf;
 const MAX_NUM_NODE_WRITERS: usize = 25;
 /// Corresponds to cells of up to about 10m x 10m.
 const S2_SPLIT_LEVEL: u64 = 20;
-/// Lower bound for distance from earth's center.
-/// See https://en.wikipedia.org/wiki/Earth_radius#Geophysical_extremes
-const EARTH_RADIUS_MIN_M: f64 = 6_352_800.0;
-/// Upper bound for distance from earth's center.
-/// See https://en.wikipedia.org/wiki/Earth_radius#Geophysical_extremes
-const EARTH_RADIUS_MAX_M: f64 = 6_384_400.0;
 
 pub struct S2Splitter<W> {
     writers: LruCache<CellID, W>,

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -145,7 +145,9 @@ impl PointCloud for S2Cells {
                     .map(|p| Point3::from_homogeneous(world_from_clip * p));
                 self.cells_in_convex_hull(points)
             }
-            PointLocation::OrientedBeam(_) => unimplemented!(),
+            PointLocation::OrientedBeam(beam) => {
+                self.cells_in_obb(&Obb::from(beam), query.global_from_local.as_ref())
+            }
         }
     }
 

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -183,10 +183,7 @@ impl S2Cells {
         global_from_local: Option<&Isometry3<f64>>,
     ) -> Vec<S2CellId> {
         let obb = match global_from_local {
-            Some(isometry) => Cow::Owned(Obb::new(
-                isometry * &obb.isometry_inv.inverse(),
-                obb.half_extent,
-            )),
+            Some(isometry) => Cow::Owned(Obb::new(isometry * &obb.isometry, obb.half_extent)),
             None => Cow::Borrowed(obb),
         };
         let points = obb.corners;


### PR DESCRIPTION
This solution simply intersects the oriented beam with the min and max earth radius to create an OBB and treats the query as an OBB query.