### PR TITLE
Introduce batches for all iterators.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,6 +1637,7 @@ dependencies = [
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "point_viewer 0.1.0",
  "point_viewer_grpc_proto_rust 0.1.0",

--- a/point_viewer_grpc/Cargo.toml
+++ b/point_viewer_grpc/Cargo.toml
@@ -27,6 +27,7 @@ ctrlc = "3.1.2"
 futures = "0.1.17"
 grpcio = "0.4"
 num_cpus ="1.10.1"
+num-integer = "0.1.41"
 protobuf = "2.8.0"
 scoped-pool = "1.0.0"
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,9 +1,9 @@
 use crate::errors::*;
 use crate::math::PointCulling;
 use crate::math::{AllPoints, Frustum, Isometry3, Obb, OrientedBeam};
-use crate::read_write::{Encoding, PointIterator};
-use crate::{AttributeData, Point, PointsBatch};
-use cgmath::{Matrix4, Point3, Vector3};
+use crate::read_write::{Encoding, NodeIterator};
+use crate::PointsBatch;
+use cgmath::{Matrix4, Point3};
 use collision::Aabb3;
 use crossbeam::deque::{Injector, Steal, Worker};
 use std::collections::BTreeMap;
@@ -45,17 +45,24 @@ impl PointQuery {
 /// Essentially a specialized version of the Filter iterator adapter
 pub struct FilteredIterator {
     pub culling: Box<dyn PointCulling<f64>>,
-    pub point_iterator: PointIterator,
+    pub node_iterator: NodeIterator,
 }
 
 impl Iterator for FilteredIterator {
-    type Item = Point;
+    type Item = PointsBatch;
 
-    fn next(&mut self) -> Option<Point> {
+    fn next(&mut self) -> Option<PointsBatch> {
         let culling = &self.culling;
-        self.point_iterator.find(|pt| {
-            let pos = <Point3<f64> as cgmath::EuclideanSpace>::from_vec(pt.position);
-            culling.contains(&pos)
+        self.node_iterator.next().map(|mut batch| {
+            let keep: Vec<bool> = batch
+                .position
+                .iter()
+                .map(|pos| {
+                    culling.contains(&<Point3<f64> as cgmath::EuclideanSpace>::from_vec(*pos))
+                })
+                .collect();
+            batch.retain(&keep);
+            batch
         })
     }
 }
@@ -65,9 +72,8 @@ struct PointStream<'a, F>
 where
     F: Fn(PointsBatch) -> Result<()>,
 {
-    position: Vec<Vector3<f64>>,
-    color: Vec<Vector3<u8>>,
-    intensity: Vec<f32>,
+    buf: PointsBatch,
+    batch_size: usize,
     local_from_global: &'a Option<Isometry3<f64>>,
     func: &'a F,
 }
@@ -76,68 +82,44 @@ impl<'a, F> PointStream<'a, F>
 where
     F: Fn(PointsBatch) -> Result<()>,
 {
-    fn new(
-        num_points_per_batch: usize,
-        local_from_global: &'a Option<Isometry3<f64>>,
-        func: &'a F,
-    ) -> Self {
+    fn new(batch_size: usize, local_from_global: &'a Option<Isometry3<f64>>, func: &'a F) -> Self {
         PointStream {
-            position: Vec::with_capacity(num_points_per_batch),
-            color: Vec::with_capacity(num_points_per_batch),
-            intensity: Vec::with_capacity(num_points_per_batch),
+            buf: PointsBatch {
+                position: Vec::new(),
+                attributes: BTreeMap::new(),
+            },
+            batch_size,
             local_from_global,
             func,
         }
     }
 
-    /// push point in batch
-    fn push_point(&mut self, point: Point) {
-        let position = match &self.local_from_global {
-            Some(local_from_global) => local_from_global * &point.position,
-            None => point.position,
-        };
-        self.position.push(position);
-        self.color.push(Vector3::new(
-            point.color.red,
-            point.color.green,
-            point.color.blue,
-        ));
-        if let Some(point_intensity) = point.intensity {
-            self.intensity.push(point_intensity);
-        };
-    }
-
     /// execute function on batch of points
     fn callback(&mut self) -> Result<()> {
-        if self.position.is_empty() {
+        if self.buf.position.is_empty() {
             return Ok(());
         }
 
-        let mut attributes = BTreeMap::default();
-        attributes.insert(
-            "color".to_string(),
-            AttributeData::U8Vec3(self.color.split_off(0)),
-        );
-        if !self.intensity.is_empty() {
-            attributes.insert(
-                "intensity".to_string(),
-                AttributeData::F32(self.intensity.split_off(0)),
-            );
-        }
-        let points_batch = PointsBatch {
-            position: self.position.split_off(0),
-            attributes,
-        };
-        (self.func)(points_batch)
+        let at = std::cmp::min(self.buf.position.len(), self.batch_size);
+        let mut res = self.buf.split_off(at);
+        std::mem::swap(&mut res, &mut self.buf);
+        (self.func)(res)
     }
 
-    fn push_points_and_callback<I>(&mut self, point_iterator: I) -> Result<()>
+    fn push_points_and_callback<I>(&mut self, node_iterator: I) -> Result<()>
     where
-        I: Iterator<Item = Point>,
+        I: Iterator<Item = PointsBatch>,
     {
-        for point in point_iterator {
-            self.push_point(point);
-            if self.position.len() == self.position.capacity() {
+        for mut batch in node_iterator {
+            if let Some(local_from_global) = &self.local_from_global {
+                batch.position = batch
+                    .position
+                    .iter()
+                    .map(|p| local_from_global * p)
+                    .collect();
+            }
+            self.buf.append(&mut batch)?;
+            while self.buf.position.len() >= self.batch_size {
                 self.callback()?;
             }
         }
@@ -148,10 +130,15 @@ where
 // TODO(nnmm): Move this somewhere else
 pub trait PointCloud: Sync {
     type Id: ToString + Send + Copy;
-    type PointsIter: Iterator<Item = Point>;
+    type PointsIter: Iterator<Item = PointsBatch>;
     fn nodes_in_location(&self, query: &PointQuery) -> Vec<Self::Id>;
     fn encoding_for_node(&self, id: Self::Id) -> Encoding;
-    fn points_in_node(&self, query: &PointQuery, node_id: Self::Id) -> Result<Self::PointsIter>;
+    fn points_in_node(
+        &self,
+        query: &PointQuery,
+        node_id: Self::Id,
+        batch_size: usize,
+    ) -> Result<Self::PointsIter>;
 }
 
 /// Iterator on point batches
@@ -238,11 +225,11 @@ where
                             .and_then(Steal::success)
                     }) {
                         // TODO(nnmm): This crashes on error. We should bubble up an error.
-                        let point_iterator = octree
-                            .points_in_node(&point_location, node_id)
+                        let node_iterator = octree
+                            .points_in_node(&point_location, node_id, batch_size)
                             .expect("Could not read node points");
                         // executing on the available next task if the function still requires it
-                        match point_stream.push_points_and_callback(point_iterator) {
+                        match point_stream.push_points_and_callback(node_iterator) {
                             Ok(_) => continue,
                             Err(ref e) => {
                                 match e.kind() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub const CURRENT_VERSION: i32 = 12;
 pub const NUM_POINTS_PER_BATCH: usize = 500_000;
 
 pub trait NumberOfPoints {
-    fn num_points(&self) -> Option<usize>;
+    fn num_points(&self) -> usize;
 }
 
 #[derive(Debug, Clone)]
@@ -50,29 +50,6 @@ pub struct Point {
     // The intensity of the point if it exists. This value is usually handed through directly by a
     // sensor and has therefore no defined range - or even meaning.
     pub intensity: Option<f32>,
-}
-
-// TODO(feuerste): Remove this temporary helper, once all iterators work on PointsBatch
-impl From<PointsBatch> for Point {
-    fn from(batch: PointsBatch) -> Self {
-        assert!(batch.position.len() == 1);
-        let color_vec: &Vec<Vector3<u8>> = batch.get_attribute_vec("color").unwrap();
-        let rgb = color_vec[0];
-        let color = color::Color {
-            red: rgb.x,
-            green: rgb.y,
-            blue: rgb.z,
-            alpha: 255,
-        };
-        let intensity_vec: Option<&Vec<f32>> = batch.get_attribute_vec("intensity").ok();
-        let intensity = intensity_vec.map(|vec| vec[0]);
-        let position = batch.position[0];
-        Self {
-            position,
-            color,
-            intensity,
-        }
-    }
 }
 
 pub fn attribute_extension(attribute: &str) -> &str {

--- a/src/octree/generation.rs
+++ b/src/octree/generation.rs
@@ -254,7 +254,10 @@ impl Iterator for OnePointPlyIterator {
 fn find_bounding_box(filename: impl AsRef<Path>) -> Aabb3<f64> {
     let mut num_points = 0i64;
     let mut bounding_box = Aabb3::zero();
-    let stream = PlyIterator::from_file(filename).unwrap();
+    // TODO(feuerste): Adjust batch size once all iterators work on PointsBatch
+    let stream = OnePointPlyIterator {
+        inner: PlyIterator::from_file(filename, 1).unwrap(),
+    };
     let mut progress_bar = ProgressBar::new(stream.size_hint().1.unwrap() as u64);
     progress_bar.message("Determining bounding box: ");
 
@@ -280,7 +283,10 @@ pub fn build_octree_from_file(
     filename: impl AsRef<Path>,
 ) {
     let bounding_box = find_bounding_box(filename.as_ref());
-    let stream = PlyIterator::from_file(filename).unwrap();
+    // TODO(feuerste): Adjust batch size once all iterators work on PointsBatch
+    let stream = OnePointPlyIterator {
+        inner: PlyIterator::from_file(filename, 1).unwrap(),
+    };
     build_octree(pool, output_directory, resolution, bounding_box, stream)
 }
 

--- a/src/octree/generation.rs
+++ b/src/octree/generation.rs
@@ -254,10 +254,7 @@ impl Iterator for OnePointPlyIterator {
 fn find_bounding_box(filename: impl AsRef<Path>) -> Aabb3<f64> {
     let mut num_points = 0i64;
     let mut bounding_box = Aabb3::zero();
-    // TODO(feuerste): Adjust batch size once all iterators work on PointsBatch
-    let stream = OnePointPlyIterator {
-        inner: PlyIterator::from_file(filename, 1).unwrap(),
-    };
+    let stream = PlyIterator::from_file(filename).unwrap();
     let mut progress_bar = ProgressBar::new(stream.size_hint().1.unwrap() as u64);
     progress_bar.message("Determining bounding box: ");
 
@@ -283,10 +280,7 @@ pub fn build_octree_from_file(
     filename: impl AsRef<Path>,
 ) {
     let bounding_box = find_bounding_box(filename.as_ref());
-    // TODO(feuerste): Adjust batch size once all iterators work on PointsBatch
-    let stream = OnePointPlyIterator {
-        inner: PlyIterator::from_file(filename, 1).unwrap(),
-    };
+    let stream = PlyIterator::from_file(filename).unwrap();
     build_octree(pool, output_directory, resolution, bounding_box, stream)
 }
 

--- a/src/octree/generation.rs
+++ b/src/octree/generation.rs
@@ -34,6 +34,7 @@ use std::fs::{self, File};
 use std::io::BufWriter;
 use std::path::Path;
 use std::sync::mpsc;
+use std::time::Duration;
 
 const MAX_POINTS_PER_NODE: i64 = 100_000;
 
@@ -257,6 +258,7 @@ fn find_bounding_box(filename: impl AsRef<Path>) -> Aabb3<f64> {
     let mut bounding_box = None;
     let stream = PlyIterator::from_file(filename, NUM_POINTS_PER_BATCH).unwrap();
     let mut progress_bar = ProgressBar::new(stream.num_points() as u64);
+    progress_bar.set_max_refresh_rate(Some(Duration::from_secs(2)));
     progress_bar.message("Determining bounding box: ");
 
     stream.for_each(|batch| {

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -14,7 +14,7 @@
 use crate::errors::*;
 use crate::math::Cube;
 use crate::proto;
-use crate::read_write::{Encoding, PointIterator, PositionEncoding};
+use crate::read_write::{Encoding, NodeIterator, PositionEncoding};
 use crate::CURRENT_VERSION;
 use cgmath::{EuclideanSpace, Matrix4, Point3};
 use collision::{Aabb, Aabb3, Relation};
@@ -352,17 +352,19 @@ impl PointCloud for Octree {
         &'a self,
         query: &PointQuery,
         node_id: NodeId,
+        batch_size: usize,
     ) -> Result<FilteredIterator> {
         let culling = query.get_point_culling();
-        let point_iterator = PointIterator::from_data_provider(
+        let node_iterator = NodeIterator::from_data_provider(
             &*self.data_provider,
             self.meta.encoding_for_node(node_id),
             &node_id,
             self.nodes[&node_id].num_points as usize,
+            batch_size,
         )?;
         Ok(FilteredIterator {
             culling,
-            point_iterator,
+            node_iterator,
         })
     }
 }

--- a/src/octree/octree_iterator.rs
+++ b/src/octree/octree_iterator.rs
@@ -1,19 +1,20 @@
 use crate::errors::*;
 use crate::octree::{ChildIndex, DataProvider, NodeId, Octree};
-use crate::read_write::{AttributeReader, Encoding, PointIterator, RawNodeReader};
+use crate::read_write::{AttributeReader, Encoding, NodeIterator, RawNodeReader};
 use crate::AttributeDataType;
 use std::collections::{HashMap, VecDeque};
 use std::io::BufReader;
 
-impl PointIterator {
+impl NodeIterator {
     pub fn from_data_provider<Id: ToString>(
         data_provider: &dyn DataProvider,
         encoding: Encoding,
         id: &Id,
         num_points: usize,
+        batch_size: usize,
     ) -> Result<Self> {
         if num_points == 0 {
-            return Ok(PointIterator::default());
+            return Ok(NodeIterator::default());
         }
 
         let mut attributes = HashMap::new();
@@ -50,6 +51,7 @@ impl PointIterator {
         Ok(Self::new(
             RawNodeReader::new(position_read, attributes, encoding)?,
             num_points,
+            batch_size,
         ))
     }
 }

--- a/src/octree/octree_test.rs
+++ b/src/octree/octree_test.rs
@@ -1,30 +1,34 @@
 #[cfg(test)]
 mod tests {
-    use crate::color::Color;
     use crate::errors::Result;
     use crate::iterator::{ParallelIterator, PointLocation, PointQuery};
     use crate::octree::{self, build_octree, Octree};
-    use crate::{Point, PointsBatch};
+    use crate::{AttributeData, NumberOfPoints, PointsBatch};
     use cgmath::{EuclideanSpace, Point3, Vector3};
     use collision::{Aabb, Aabb3};
     use tempdir::TempDir;
 
     const NUM_POINTS: usize = 100_001;
 
+    impl<T> NumberOfPoints for std::vec::IntoIter<T> {
+        fn num_points(&self) -> usize {
+            self.len()
+        }
+    }
+
     fn build_big_test_octree() -> Box<octree::Octree> {
-        let default_point = Point {
-            position: Vector3::new(-2_699_182.0, -4_294_938.0, 3_853_373.0), //ECEF parking lot porter dr
-            color: Color {
-                red: 255,
-                green: 0,
-                blue: 0,
-                alpha: 255,
-            },
-            intensity: None,
+        let mut batch = PointsBatch {
+            //ECEF parking lot porter dr
+            position: vec![Vector3::new(-2_699_182.0, -4_294_938.0, 3_853_373.0); 2 * NUM_POINTS],
+            attributes: vec![(
+                "color".to_string(),
+                AttributeData::U8Vec3(vec![Vector3::new(255, 0, 0); 2 * NUM_POINTS]),
+            )]
+            .into_iter()
+            .collect(),
         };
 
-        let mut points = vec![default_point; 2 * NUM_POINTS];
-        points[3].position = Vector3::new(-2_702_846.0, -4_291_151.0, 3_855_012.0); // ECEF STANFORD
+        batch.position[3] = Vector3::new(-2_702_846.0, -4_291_151.0, 3_855_012.0); // ECEF STANFORD
 
         let p = Point3::new(6_400_000.0, 6_400_000.0, 6_400_000.0);
         let bounding_box = Aabb3::new(-1.0 * p, p);
@@ -32,31 +36,29 @@ mod tests {
         let pool = scoped_pool::Pool::new(10);
         let tmp_dir = TempDir::new("octree").unwrap();
 
-        build_octree(&pool, &tmp_dir, 1.0, bounding_box, points.into_iter());
+        build_octree(&pool, &tmp_dir, 1.0, bounding_box, vec![batch].into_iter());
         crate::octree::octree_from_directory(tmp_dir.into_path()).unwrap()
     }
 
     fn build_test_octree() -> Box<octree::Octree> {
-        let default_point = Point {
-            position: Vector3::new(0.0, 0.0, 0.0),
-            color: Color {
-                red: 255,
-                green: 0,
-                blue: 0,
-                alpha: 255,
-            },
-            intensity: None,
+        let mut batch = PointsBatch {
+            position: vec![Vector3::new(0.0, 0.0, 0.0); NUM_POINTS],
+            attributes: vec![(
+                "color".to_string(),
+                AttributeData::U8Vec3(vec![Vector3::new(255, 0, 0); NUM_POINTS]),
+            )]
+            .into_iter()
+            .collect(),
         };
 
-        let mut points = vec![default_point; NUM_POINTS];
-        points[NUM_POINTS - 1].position = Vector3::new(-200., -40., 30.);
+        batch.position[NUM_POINTS - 1] = Vector3::new(-200., -40., 30.);
 
-        let bounding_box = Aabb3::zero().grow(Point3::from_vec(points[100_000].position));
+        let bounding_box = Aabb3::zero().grow(Point3::from_vec(batch.position[100_000]));
 
         let pool = scoped_pool::Pool::new(10);
         let tmp_dir = TempDir::new("octree").unwrap();
 
-        build_octree(&pool, &tmp_dir, 1.0, bounding_box, points.into_iter());
+        build_octree(&pool, &tmp_dir, 1.0, bounding_box, vec![batch].into_iter());
         crate::octree::octree_from_directory(tmp_dir.into_path()).unwrap()
     }
 

--- a/src/read_write/mod.rs
+++ b/src/read_write/mod.rs
@@ -19,7 +19,7 @@ pub use self::codec::{
 };
 
 mod node_iterator;
-pub use self::node_iterator::PointIterator;
+pub use self::node_iterator::NodeIterator;
 
 mod node_writer;
 pub use self::node_writer::{DataWriter, NodeWriter, OpenMode, WriteEncoded, WriteLE, WriteLEPos};

--- a/src/read_write/node_iterator.rs
+++ b/src/read_write/node_iterator.rs
@@ -13,50 +13,65 @@
 // limitations under the License.
 
 use crate::read_write::RawNodeReader;
-use crate::Point;
+use crate::{NumberOfPoints, PointsBatch};
+use num_integer::div_ceil;
 
 /// Streams points from our data provider representation.
-pub struct PointIterator {
+pub struct NodeIterator {
     reader: Option<RawNodeReader>,
     num_points: usize,
     point_count: usize,
+    batch_size: usize,
 }
 
-impl Default for PointIterator {
+impl Default for NodeIterator {
     fn default() -> Self {
-        PointIterator {
+        NodeIterator {
             reader: None,
             num_points: 0,
             point_count: 0,
+            batch_size: 0,
         }
     }
 }
 
-impl PointIterator {
-    pub fn new(reader: RawNodeReader, num_points: usize) -> Self {
+impl NodeIterator {
+    pub fn new(reader: RawNodeReader, num_points: usize, batch_size: usize) -> Self {
         if num_points == 0 {
-            return PointIterator::default();
+            return NodeIterator::default();
         }
 
-        PointIterator {
+        NodeIterator {
             reader: Some(reader),
             num_points,
             point_count: 0,
+            batch_size,
         }
     }
 }
 
-impl Iterator for PointIterator {
-    type Item = Point;
+impl NumberOfPoints for NodeIterator {
+    fn num_points(&self) -> usize {
+        self.num_points
+    }
+}
+
+impl Iterator for NodeIterator {
+    type Item = PointsBatch;
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.num_points, Some(self.num_points))
+        let num_batches = div_ceil(self.num_points, self.batch_size);
+        (num_batches, Some(num_batches))
     }
-    fn next(&mut self) -> Option<Point> {
+    fn next(&mut self) -> Option<PointsBatch> {
         if let Some(reader) = &mut self.reader {
             if self.point_count < self.num_points {
-                let res = reader.read().expect("Couldn't read from node.");
-                self.point_count += 1;
+                let num_points_to_read =
+                    std::cmp::min(self.batch_size, self.num_points - self.point_count);
+                let res = reader
+                    .read_batch(num_points_to_read)
+                    .expect("Couldn't read from node.");
+                self.point_count += num_points_to_read;
                 return Some(res);
             }
         }

--- a/src/read_write/ply.rs
+++ b/src/read_write/ply.rs
@@ -16,7 +16,7 @@ use crate::errors::*;
 use crate::read_write::{
     DataWriter, Encoding, NodeWriter, OpenMode, PositionEncoding, WriteEncoded, WriteLE, WriteLEPos,
 };
-use crate::{AttributeData, Point, PointsBatch};
+use crate::{AttributeData, NumberOfPoints, Point, PointsBatch};
 use byteorder::{ByteOrder, LittleEndian};
 use cgmath::Vector3;
 use num_integer::div_ceil;
@@ -507,6 +507,12 @@ fn batch_from_readers(readers: &mut [PropertyReader], offset: &Vector3<f64>) -> 
     PointsBatch {
         position,
         attributes,
+    }
+}
+
+impl NumberOfPoints for PlyIterator {
+    fn num_points(&self) -> usize {
+        self.num_total_points as usize
     }
 }
 

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -3,7 +3,7 @@ use crate::errors::*;
 use crate::iterator::{FilteredIterator, PointCloud, PointLocation, PointQuery};
 use crate::math::{Isometry3, Obb};
 use crate::proto;
-use crate::read_write::{Encoding, PointIterator};
+use crate::read_write::{Encoding, NodeIterator};
 use crate::{AttributeDataType, CURRENT_VERSION};
 use cgmath::{Point3, Transform, Vector4};
 use fnv::FnvHashMap;
@@ -178,18 +178,20 @@ impl PointCloud for S2Cells {
         &'a self,
         query: &PointQuery,
         node_id: Self::Id,
+        batch_size: usize,
     ) -> Result<Self::PointsIter> {
         let culling = query.get_point_culling();
         let num_points = self.meta.cells[&node_id.0].num_points as usize;
-        let point_iterator = PointIterator::from_data_provider(
+        let node_iterator = NodeIterator::from_data_provider(
             &*self.data_provider,
             self.encoding_for_node(node_id),
             &node_id,
             num_points,
+            batch_size,
         )?;
         Ok(FilteredIterator {
             culling,
-            point_iterator,
+            node_iterator,
         })
     }
 }


### PR DESCRIPTION
I accidentally closed #356. This is its continuation.

This PR changes all iterators used by the point cloud client to return `PointsBatche`s instead of `Point`s. This enables reading of all attributes by the client instead of just position, color, and intensity.

Please review with `Hide whitespace changes` turned on.