### PR TITLE
Verify frustum query equivalence between point cloud flavors

### DIFF
--- a/benches/generate_and_query/random_points.rs
+++ b/benches/generate_and_query/random_points.rs
@@ -43,10 +43,14 @@ impl RandomPointsOnEarth {
         self.ecef_from_local.transform_point(pt_local)
     }
 
-    pub fn bbox(&mut self) -> Aabb3<f64> {
+    pub fn bbox(&self) -> Aabb3<f64> {
         let local_min = Point3::new(-self.half_width, -self.half_width, -self.half_height);
         let local_max = Point3::new(self.half_width, self.half_width, self.half_height);
         Aabb3::new(local_min, local_max).transform(&self.ecef_from_local)
+    }
+
+    pub fn ecef_from_local(&self) -> &Matrix4<f64> {
+        &self.ecef_from_local
     }
 }
 


### PR DESCRIPTION
Plus subsuming `get_octree()`, `get_s2_cells()`, `Arguments::default()` and `RandomPointsOnEarth::new()` into a `setup()` function.