### PR TITLE
Fix frustum query, clarify transformations.

### DIFF
--- a/benches/generate_and_query/main.rs
+++ b/benches/generate_and_query/main.rs
@@ -245,7 +245,7 @@ fn check_all_query_equality() {
     let query = PointQuery {
         attributes: vec!["color"],
         location: PointLocation::AllPoints,
-        global_from_local: None,
+        global_from_query: None,
     };
     let points_s2 = query_and_sort(&s2, &query, args.batch_size);
     let points_oct = query_and_sort(&oct, &query, args.batch_size);
@@ -259,7 +259,7 @@ fn check_box_query_equality() {
     let query = PointQuery {
         attributes: vec!["color"],
         location: PointLocation::Aabb(bbox),
-        global_from_local: None,
+        global_from_query: None,
     };
     let points_s2 = query_and_sort(&s2, &query, args.batch_size);
     let points_oct = query_and_sort(&oct, &query, args.batch_size);
@@ -281,7 +281,7 @@ fn check_frustum_query_equality() {
     let query = PointQuery {
         attributes: vec!["color"],
         location: PointLocation::Frustum(frustum),
-        global_from_local: None,
+        global_from_query: None,
     };
     let points_s2 = query_and_sort(&s2, &query, args.batch_size);
     let points_oct = query_and_sort(&oct, &query, args.batch_size);
@@ -296,7 +296,7 @@ fn check_beam_query_equality() {
     let query = PointQuery {
         attributes: vec!["color"],
         location: PointLocation::OrientedBeam(beam),
-        global_from_local: None,
+        global_from_query: None,
     };
     let points_oct = query_and_sort(&oct, &query, args.batch_size);
     let points_s2 = query_and_sort(&s2, &query, args.batch_size);

--- a/point_cloud_client/src/bin/test.rs
+++ b/point_cloud_client/src/bin/test.rs
@@ -72,7 +72,7 @@ fn main() {
     let point_location = PointQuery {
         attributes: vec!["color", "intensity"],
         location: PointLocation::Aabb(Aabb3::new(args.min, args.max)),
-        global_from_local: None,
+        global_from_query: None,
     };
     let mut point_count: usize = 0;
     let mut print_count: usize = 1;

--- a/point_viewer_grpc/src/bin/octree_benchmark.rs
+++ b/point_viewer_grpc/src/bin/octree_benchmark.rs
@@ -102,7 +102,7 @@ fn server_benchmark(
     let all_points = PointQuery {
         attributes: vec!["color", "intensity"],
         location: PointLocation::AllPoints,
-        global_from_local: None,
+        global_from_query: None,
     };
     let octree_slice: &[Octree] = std::slice::from_ref(&octree);
     let mut parallel_iterator = ParallelIterator::new(

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -323,7 +323,7 @@ impl OctreeService {
                 let point_query = PointQuery {
                     attributes: vec!["color", "intensity"],
                     location,
-                    global_from_local: None,
+                    global_from_query: None,
                 };
                 let mut parallel_iterator = ParallelIterator::new(
                     octree_slice,

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -15,9 +15,7 @@
 use crate::proto;
 use crate::proto_grpc;
 use crate::Color;
-use cgmath::{
-    Decomposed, Matrix4, PerspectiveFov, Point3, Quaternion, Rad, Transform, Vector2, Vector3,
-};
+use cgmath::{PerspectiveFov, Point3, Quaternion, Rad, Vector2, Vector3};
 use collision::Aabb3;
 use futures::sync::mpsc;
 use futures::{Future, Sink, Stream};
@@ -29,7 +27,7 @@ use num_cpus;
 use point_viewer::data_provider::DataProviderFactory;
 use point_viewer::errors::*;
 use point_viewer::iterator::{ParallelIterator, PointLocation, PointQuery};
-use point_viewer::math::{Isometry3, OrientedBeam};
+use point_viewer::math::{Frustum, Isometry3, OrientedBeam};
 use point_viewer::octree::{NodeId, Octree};
 use point_viewer::{AttributeData, PointsBatch};
 use protobuf::Message;
@@ -119,12 +117,13 @@ impl proto_grpc::Octree for OctreeService {
         req: proto::GetPointsInFrustumRequest,
         resp: ServerStreamingSink<proto::PointsReply>,
     ) {
-        let projection_matrix = Matrix4::from(PerspectiveFov {
+        let perspective = PerspectiveFov {
             fovy: Rad(req.fovy_rad),
             aspect: req.aspect,
             near: req.z_near,
             far: req.z_far,
-        });
+        }
+        .to_perspective();
         let rotation = {
             let q = req.rotation.unwrap();
             Quaternion::new(q.w, q.x, q.y, q.z)
@@ -135,13 +134,12 @@ impl proto_grpc::Octree for OctreeService {
             Vector3::new(t.x, t.y, t.z)
         };
 
-        let view_transform = Decomposed {
-            scale: 1.0,
-            rot: rotation,
-            disp: translation,
+        let view_transform = Isometry3::<f64> {
+            rotation,
+            translation,
         };
-        let frustum_matrix = projection_matrix.concat(&view_transform.into());
-        let location = PointLocation::Frustum(frustum_matrix);
+        let frustum = Frustum::new(view_transform, perspective);
+        let location = PointLocation::Frustum(frustum);
         self.stream_points_back_to_sink(location, &req.octree_id, &ctx, resp)
     }
 

--- a/sdl_viewer/src/terrain_drawer/layer.rs
+++ b/sdl_viewer/src/terrain_drawer/layer.rs
@@ -3,7 +3,7 @@ use crate::graphic::tiled_texture_loader::TiledTextureLoader;
 use crate::graphic::uniform::GlUniform;
 use crate::graphic::GlProgram;
 use crate::terrain_drawer::read_write::Metadata;
-use cgmath::{Decomposed, Matrix4, Vector2, Vector3, Zero};
+use cgmath::{Decomposed, Matrix4, Point3, Vector2, Vector3};
 use image::{ImageBuffer, LumaA, Rgba};
 use point_viewer::math::Isometry3;
 use std::convert::TryInto;
@@ -50,7 +50,7 @@ impl TerrainLayer {
 
         // Initial terrain pos
         let terrain_pos: Vector2<i64> =
-            grid_coordinates.terrain_pos_for_camera_pos(Vector3::zero());
+            grid_coordinates.terrain_pos_for_camera_pos(Point3::new(0.0, 0.0, 0.0));
         let u_terrain_pos = GlUniform::new(&program, "terrain_pos", terrain_pos.cast().unwrap());
 
         let height_initial = height_tiles.load(
@@ -100,7 +100,7 @@ impl TerrainLayer {
     // Only fetch the "L" shape that is needed, as separate horizontal and vertical strips.
     // Don't get confused, the horizontal strip is determined by the movement in y direction and
     // the vertical strip is determined by the movement in x direction.
-    pub fn update(&mut self, cur_world_pos: Vector3<f64>) {
+    pub fn update(&mut self, cur_world_pos: Point3<f64>) {
         let cur_pos = self
             .grid_coordinates
             .terrain_pos_for_camera_pos(cur_world_pos);
@@ -218,7 +218,7 @@ impl GridCoordinateFrame {
 
     /// Returns the terrain pos (i.e. the coordinate of the lower corner of the terrain) for
     /// a given camera position (in the world coordinate system).
-    fn terrain_pos_for_camera_pos(&self, world_pos: Vector3<f64>) -> Vector2<i64> {
+    fn terrain_pos_for_camera_pos(&self, world_pos: Point3<f64>) -> Vector2<i64> {
         let local_pos = &self.terrain_from_world * &world_pos;
         let x = ((local_pos.x - self.u_origin.value.x) / self.u_resolution_m.value).floor();
         let y = ((local_pos.y - self.u_origin.value.y) / self.u_resolution_m.value).floor();

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -3,7 +3,7 @@ use crate::math::PointCulling;
 use crate::math::{AllPoints, Frustum, Isometry3, Obb, OrientedBeam};
 use crate::read_write::{Encoding, NodeIterator};
 use crate::PointsBatch;
-use cgmath::Point3;
+use cgmath::{EuclideanSpace, Point3};
 use collision::Aabb3;
 use crossbeam::deque::{Injector, Steal, Worker};
 use std::collections::BTreeMap;
@@ -116,7 +116,7 @@ where
                 batch.position = batch
                     .position
                     .iter()
-                    .map(|p| local_from_global * p)
+                    .map(|p| (local_from_global * &Point3::from_vec(*p)).to_vec())
                     .collect();
             }
             self.buf.append(&mut batch)?;

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -3,7 +3,7 @@ use crate::math::PointCulling;
 use crate::math::{AllPoints, Frustum, Isometry3, Obb, OrientedBeam};
 use crate::read_write::{Encoding, NodeIterator};
 use crate::PointsBatch;
-use cgmath::{Matrix4, Point3};
+use cgmath::Point3;
 use collision::Aabb3;
 use crossbeam::deque::{Injector, Steal, Worker};
 use std::collections::BTreeMap;
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 pub enum PointLocation {
     AllPoints,
     Aabb(Aabb3<f64>),
-    Frustum(Matrix4<f64>),
+    Frustum(Frustum<f64>),
     Obb(Obb<f64>),
     OrientedBeam(OrientedBeam<f64>),
 }
@@ -31,7 +31,7 @@ impl<'a> PointQuery<'a> {
         let culling: Box<dyn PointCulling<f64>> = match &self.location {
             PointLocation::AllPoints => return Box::new(AllPoints {}),
             PointLocation::Aabb(aabb) => Box::new(*aabb),
-            PointLocation::Frustum(matrix) => Box::new(Frustum::new(*matrix)),
+            PointLocation::Frustum(frustum) => Box::new(frustum.clone()),
             PointLocation::Obb(obb) => Box::new(obb.clone()),
             PointLocation::OrientedBeam(beam) => Box::new(beam.clone()),
         };

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -23,7 +23,8 @@ pub struct PointQuery<'a> {
     pub attributes: Vec<&'a str>,
     pub location: PointLocation,
     // If set, culling and the returned points are interpreted to be in local coordinates.
-    pub global_from_local: Option<Isometry3<f64>>,
+    // Otherwise, the query is assumed to already be in global coordinates.
+    pub global_from_query: Option<Isometry3<f64>>,
 }
 
 impl<'a> PointQuery<'a> {
@@ -35,8 +36,8 @@ impl<'a> PointQuery<'a> {
             PointLocation::Obb(obb) => Box::new(obb.clone()),
             PointLocation::OrientedBeam(beam) => Box::new(beam.clone()),
         };
-        match &self.global_from_local {
-            Some(global_from_local) => culling.transform(&global_from_local),
+        match &self.global_from_query {
+            Some(global_from_query) => culling.transform(&global_from_query),
             None => culling,
         }
     }
@@ -75,7 +76,7 @@ where
 {
     buf: PointsBatch,
     batch_size: usize,
-    local_from_global: &'a Option<Isometry3<f64>>,
+    query_from_global: &'a Option<Isometry3<f64>>,
     func: &'a F,
 }
 
@@ -83,14 +84,14 @@ impl<'a, F> PointStream<'a, F>
 where
     F: Fn(PointsBatch) -> Result<()>,
 {
-    fn new(batch_size: usize, local_from_global: &'a Option<Isometry3<f64>>, func: &'a F) -> Self {
+    fn new(batch_size: usize, query_from_global: &'a Option<Isometry3<f64>>, func: &'a F) -> Self {
         PointStream {
             buf: PointsBatch {
                 position: Vec::new(),
                 attributes: BTreeMap::new(),
             },
             batch_size,
-            local_from_global,
+            query_from_global,
             func,
         }
     }
@@ -112,11 +113,11 @@ where
         I: Iterator<Item = PointsBatch>,
     {
         for mut batch in node_iterator {
-            if let Some(local_from_global) = &self.local_from_global {
+            if let Some(query_from_global) = &self.query_from_global {
                 batch.position = batch
                     .position
                     .iter()
-                    .map(|p| (local_from_global * &Point3::from_vec(*p)).to_vec())
+                    .map(|p| (query_from_global * &Point3::from_vec(*p)).to_vec())
                     .collect();
             }
             self.buf.append(&mut batch)?;
@@ -190,9 +191,9 @@ where
                 number_of_jobs += 1;
             });
 
-        let local_from_global = self
+        let query_from_global = self
             .point_query
-            .global_from_local
+            .global_from_query
             .as_ref()
             .map(Isometry3::inverse);
 
@@ -201,7 +202,7 @@ where
             let (tx, rx) = crossbeam::channel::bounded::<PointsBatch>(self.buffer_size);
             for curr_thread in 0..self.num_threads {
                 let tx = tx.clone();
-                let local_from_global = &local_from_global;
+                let query_from_global = &query_from_global;
                 let point_query = &self.point_query;
                 let batch_size = self.batch_size;
                 let worker = Worker::new_fifo();
@@ -219,7 +220,7 @@ where
 
                     // one pointstream per thread vs one per node allows to send more full point batches
                     let mut point_stream =
-                        PointStream::new(batch_size, &local_from_global, &send_func);
+                        PointStream::new(batch_size, &query_from_global, &send_func);
 
                     while let Some((octree, node_id)) = worker.pop().or_else(|| {
                         std::iter::repeat_with(|| jobs.steal_batch_and_pop(&worker))

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -37,7 +37,7 @@ impl<'a> PointQuery<'a> {
             PointLocation::OrientedBeam(beam) => Box::new(beam.clone()),
         };
         match &self.global_from_query {
-            Some(global_from_query) => culling.transform(&global_from_query),
+            Some(global_from_query) => culling.transformed(&global_from_query),
             None => culling,
         }
     }

--- a/src/math.rs
+++ b/src/math.rs
@@ -457,26 +457,28 @@ where
     }
 }
 
-/// Frustum is a perspective projection with x pointing right, y pointing up,
-/// and z pointing against the viewing direction. This is not how e.g. OpenCV
+/// In frustum coordinates, x points right, y points up,
+/// and z points against the viewing direction. This is not how e.g. OpenCV
 /// defines a camera coordinate system. To get from OpenCV camera coordinates
 /// to frustum coordinates, you need to rotate 180 deg around the x axis before
-/// creating the 4x4 projection matrix, see also the frustum unit test below.
+/// creating the perspective projection, see also the frustum unit test below.
 #[derive(Debug, Clone)]
 pub struct Frustum<S: BaseFloat> {
-    pub from_frustum: Isometry3<S>,
+    from_frustum: Isometry3<S>,
     perspective: Perspective<S>,
+    pub projection: Matrix4<S>,
     frustum: collision::Frustum<S>,
 }
 
 impl<S: BaseFloat> Frustum<S> {
     pub fn new(from_frustum: Isometry3<S>, perspective: Perspective<S>) -> Self {
         let to_frustum: Decomposed<Vector3<S>, Quaternion<S>> = from_frustum.inverse().into();
-        let frustum_matrix = Matrix4::<S>::from(perspective) * Matrix4::<S>::from(to_frustum);
-        let frustum = collision::Frustum::from_matrix4(frustum_matrix).unwrap();
+        let projection = Matrix4::<S>::from(perspective) * Matrix4::<S>::from(to_frustum);
+        let frustum = collision::Frustum::from_matrix4(projection).unwrap();
         Frustum {
             from_frustum,
             perspective,
+            projection,
             frustum,
         }
     }

--- a/src/math.rs
+++ b/src/math.rs
@@ -476,10 +476,10 @@ where
     }
 }
 
-/// In frustum coordinates, x points right, y points up,
+/// A frustum is defined in eye coordinates, where x points right, y points up,
 /// and z points against the viewing direction. This is not how e.g. OpenCV
 /// defines a camera coordinate system. To get from OpenCV camera coordinates
-/// to frustum coordinates, you need to rotate 180 deg around the x axis before
+/// to eye coordinates, you need to rotate 180 deg around the x axis before
 /// creating the perspective projection, see also the frustum unit test below.
 #[derive(Debug, Clone)]
 pub struct Frustum<S: BaseFloat> {

--- a/src/math.rs
+++ b/src/math.rs
@@ -308,7 +308,7 @@ impl<S: BaseFloat> Obb<S> {
         }
     }
 
-    pub fn new_transformed(&self, global_from_query: &Isometry3<S>) -> Self {
+    pub fn clone_transformed(&self, global_from_query: &Isometry3<S>) -> Self {
         Self::new(global_from_query * &self.query_from_obb, self.half_extent)
     }
 
@@ -384,7 +384,7 @@ where
     }
 
     fn transformed(&self, global_from_query: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
-        Box::new(self.new_transformed(global_from_query))
+        Box::new(self.clone_transformed(global_from_query))
     }
 }
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -204,17 +204,17 @@ impl<'a, S: BaseFloat> Mul for &'a Isometry3<S> {
     }
 }
 
-impl<S: BaseFloat> Mul<Vector3<S>> for Isometry3<S> {
-    type Output = Vector3<S>;
-    fn mul(self, _rhs: Vector3<S>) -> Vector3<S> {
-        self.rotation * _rhs + self.translation
+impl<S: BaseFloat> Mul<Point3<S>> for Isometry3<S> {
+    type Output = Point3<S>;
+    fn mul(self, _rhs: Point3<S>) -> Point3<S> {
+        Point3::from_vec(self.rotation * _rhs.to_vec()) + self.translation
     }
 }
 
-impl<'a, S: BaseFloat> Mul<&'a Vector3<S>> for &'a Isometry3<S> {
-    type Output = Vector3<S>;
-    fn mul(self, _rhs: &'a Vector3<S>) -> Vector3<S> {
-        self.rotation * _rhs + self.translation
+impl<'a, S: BaseFloat> Mul<&'a Point3<S>> for &'a Isometry3<S> {
+    type Output = Point3<S>;
+    fn mul(self, _rhs: &'a Point3<S>) -> Point3<S> {
+        Point3::from_vec(self.rotation * _rhs.to_vec()) + self.translation
     }
 }
 
@@ -280,8 +280,11 @@ impl<S: BaseFloat> From<&OrientedBeam<S>> for Obb<S> {
     fn from(beam: &OrientedBeam<S>) -> Self {
         let earth_radius_mean = S::from(0.5 * (EARTH_RADIUS_MIN_M + EARTH_RADIUS_MAX_M)).unwrap();
         let z_off = earth_radius_mean - beam.from_beam.translation.magnitude();
-        let vec_off = Vector3::new(S::zero(), S::zero(), z_off);
-        let isometry = Isometry3::new(beam.from_beam.rotation, &beam.from_beam * &vec_off);
+        let pt_off = Point3::new(S::zero(), S::zero(), z_off);
+        let isometry = Isometry3::new(
+            beam.from_beam.rotation,
+            (&beam.from_beam * &pt_off).to_vec(),
+        );
         let z_half_extent = S::from(EARTH_RADIUS_MAX_M).unwrap() - earth_radius_mean;
         let half_extent = Vector3::new(beam.half_extent.x, beam.half_extent.y, z_half_extent);
         Self::new(isometry, half_extent)

--- a/src/math.rs
+++ b/src/math.rs
@@ -49,7 +49,7 @@ where
     fn contains(&self, point: &Point3<S>) -> bool;
     // TODO(catevita): return Relation
     fn intersects_aabb3(&self, aabb: &Aabb3<S>) -> bool;
-    fn transform(&self, isometry: &Isometry3<S>) -> Box<dyn PointCulling<S>>;
+    fn transformed(&self, isometry: &Isometry3<S>) -> Box<dyn PointCulling<S>>;
 }
 
 impl<S> PointCulling<S> for Aabb3<S>
@@ -65,8 +65,8 @@ where
         Contains::contains(self, p)
     }
 
-    fn transform(&self, isometry: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
-        Obb::from(*self).transform(isometry)
+    fn transformed(&self, isometry: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
+        Obb::from(*self).transformed(isometry)
     }
 }
 
@@ -84,7 +84,7 @@ where
     fn contains(&self, _p: &Point3<S>) -> bool {
         true
     }
-    fn transform(&self, _isometry: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
+    fn transformed(&self, _isometry: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
         Box::new(AllPoints {})
     }
 }
@@ -386,7 +386,7 @@ where
             && z.abs() <= self.half_extent.z
     }
 
-    fn transform(&self, isometry: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
+    fn transformed(&self, isometry: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
         Box::new(Self::new(isometry * &self.query_from_obb, self.half_extent))
     }
 }
@@ -465,7 +465,7 @@ where
         x.abs() <= self.half_extent.x && y.abs() <= self.half_extent.y
     }
 
-    fn transform(&self, isometry: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
+    fn transformed(&self, isometry: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
         Box::new(Self::new(
             isometry * &self.query_from_beam,
             self.half_extent,
@@ -526,7 +526,7 @@ where
         }
     }
 
-    fn transform(&self, isometry: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
+    fn transformed(&self, isometry: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
         Box::new(Self::new(
             isometry * &self.query_from_frustum,
             self.clip_from_frustum,

--- a/src/math.rs
+++ b/src/math.rs
@@ -457,7 +457,7 @@ where
 /// and z pointing against the viewing direction. This is not how e.g. OpenCV
 /// defines a camera coordinate system. To get from OpenCV camera coordinates
 /// to frustum coordinates, you need to rotate 180 deg around the x axis before
-/// createing the 4x4 projection matrix, see also the unit test below.
+/// creating the 4x4 projection matrix, see also the frustum unit test below.
 #[derive(Debug, Clone)]
 pub struct Frustum<S: BaseFloat> {
     matrix: Matrix4<S>,

--- a/src/math.rs
+++ b/src/math.rs
@@ -410,6 +410,7 @@ impl<S: BaseFloat> OrientedBeam<S> {
         }
     }
 
+    /// Not really corners, but the corners of the xy-plane centered in the origin and orthogonal to the beam.
     fn precompute_corners(
         query_from_beam: &Isometry3<S>,
         half_extent: &Vector2<S>,

--- a/src/math.rs
+++ b/src/math.rs
@@ -471,10 +471,8 @@ pub struct Frustum<S: BaseFloat> {
 
 impl<S: BaseFloat> Frustum<S> {
     pub fn new(from_frustum: Isometry3<S>, perspective: Perspective<S>) -> Self {
-        let local_from_global: Decomposed<Vector3<S>, Quaternion<S>> =
-            from_frustum.inverse().into();
-        let frustum_matrix =
-            Matrix4::<S>::from(perspective) * Matrix4::<S>::from(local_from_global);
+        let to_frustum: Decomposed<Vector3<S>, Quaternion<S>> = from_frustum.inverse().into();
+        let frustum_matrix = Matrix4::<S>::from(perspective) * Matrix4::<S>::from(to_frustum);
         let frustum = collision::Frustum::from_matrix4(frustum_matrix).unwrap();
         Frustum {
             from_frustum,

--- a/src/math.rs
+++ b/src/math.rs
@@ -483,22 +483,21 @@ where
 /// creating the perspective projection, see also the frustum unit test below.
 #[derive(Debug, Clone)]
 pub struct Frustum<S: BaseFloat> {
-    query_from_frustum: Isometry3<S>,
-    clip_from_frustum: Perspective<S>,
+    query_from_eye: Isometry3<S>,
+    clip_from_eye: Perspective<S>,
     clip_from_query: Matrix4<S>,
     frustum: collision::Frustum<S>,
 }
 
 impl<S: BaseFloat> Frustum<S> {
-    pub fn new(query_from_frustum: Isometry3<S>, clip_from_frustum: Perspective<S>) -> Self {
-        let frustum_from_query: Decomposed<Vector3<S>, Quaternion<S>> =
-            query_from_frustum.inverse().into();
+    pub fn new(query_from_eye: Isometry3<S>, clip_from_eye: Perspective<S>) -> Self {
+        let eye_from_query: Decomposed<Vector3<S>, Quaternion<S>> = query_from_eye.inverse().into();
         let clip_from_query =
-            Matrix4::<S>::from(clip_from_frustum) * Matrix4::<S>::from(frustum_from_query);
+            Matrix4::<S>::from(clip_from_eye) * Matrix4::<S>::from(eye_from_query);
         let frustum = collision::Frustum::from_matrix4(clip_from_query).unwrap();
         Frustum {
-            query_from_frustum,
-            clip_from_frustum,
+            query_from_eye,
+            clip_from_eye,
             clip_from_query,
             frustum,
         }
@@ -531,8 +530,8 @@ where
 
     fn transformed(&self, global_from_query: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
         Box::new(Self::new(
-            global_from_query * &self.query_from_frustum,
-            self.clip_from_frustum,
+            global_from_query * &self.query_from_eye,
+            self.clip_from_eye,
         ))
     }
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -455,8 +455,7 @@ where
 
     fn contains(&self, p: &Point3<S>) -> bool {
         // What is the point in beam coordinates?
-        let Point3 { x, y, .. } =
-            self.beam_from_query.rotation.rotate_point(*p) + self.beam_from_query.translation;
+        let Point3 { x, y, .. } = &self.beam_from_query * p;
         x.abs() <= self.half_extent.x && y.abs() <= self.half_extent.y
     }
 

--- a/src/octree/octree_test.rs
+++ b/src/octree/octree_test.rs
@@ -117,7 +117,7 @@ mod tests {
         let location = PointQuery {
             attributes: vec!["color"],
             location: PointLocation::AllPoints,
-            global_from_local: None,
+            global_from_query: None,
         };
         let octree_slice: &[Octree] = std::slice::from_ref(&octree);
         let mut parallel_iterator = ParallelIterator::new(
@@ -175,7 +175,7 @@ mod tests {
         let location = PointQuery {
             attributes: vec!["color"],
             location: PointLocation::AllPoints,
-            global_from_local: None,
+            global_from_query: None,
         };
 
         let octree_slice: &[Octree] = std::slice::from_ref(&octree);
@@ -222,7 +222,7 @@ mod tests {
         let location = PointQuery {
             attributes: vec!["color"],
             location: PointLocation::AllPoints,
-            global_from_local: None,
+            global_from_query: None,
         };
         let octree_slice: &[Octree] = std::slice::from_ref(&octree);
         let mut parallel_iterator = ParallelIterator::new(

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -237,7 +237,7 @@ impl S2Cells {
         global_from_query: Option<&Isometry3<f64>>,
     ) -> Vec<S2CellId> {
         let obb = match global_from_query {
-            Some(g_from_q) => Cow::Owned(obb.new_transformed(g_from_q)),
+            Some(g_from_q) => Cow::Owned(obb.clone_transformed(g_from_q)),
             None => Cow::Borrowed(obb),
         };
         let points = obb.corners();

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -171,9 +171,9 @@ impl PointCloud for S2Cells {
         match &query.location {
             PointLocation::AllPoints => self.cells.keys().cloned().map(S2CellId).collect(),
             PointLocation::Aabb(aabb) => {
-                self.cells_in_obb(&Obb::from(aabb), query.global_from_local.as_ref())
+                self.cells_in_obb(&Obb::from(aabb), query.global_from_query.as_ref())
             }
-            PointLocation::Obb(obb) => self.cells_in_obb(&obb, query.global_from_local.as_ref()),
+            PointLocation::Obb(obb) => self.cells_in_obb(&obb, query.global_from_query.as_ref()),
             PointLocation::Frustum(frustum) => {
                 let query_from_clip = frustum.clip_from_query().inverse_transform().unwrap();
                 let points = CUBE_CORNERS
@@ -182,7 +182,7 @@ impl PointCloud for S2Cells {
                 self.cells_in_convex_hull(points)
             }
             PointLocation::OrientedBeam(beam) => {
-                self.cells_in_obb(&Obb::from(beam), query.global_from_local.as_ref())
+                self.cells_in_obb(&Obb::from(beam), query.global_from_query.as_ref())
             }
         }
     }
@@ -238,9 +238,9 @@ impl S2Cells {
     fn cells_in_obb(
         &self,
         obb: &Obb<f64>,
-        global_from_local: Option<&Isometry3<f64>>,
+        global_from_query: Option<&Isometry3<f64>>,
     ) -> Vec<S2CellId> {
-        let obb = match global_from_local {
+        let obb = match global_from_query {
             Some(isometry) => Cow::Owned(Obb::new(
                 isometry * obb.query_from_obb(),
                 *obb.half_extent(),

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -5,7 +5,7 @@ use crate::math::{Isometry3, Obb};
 use crate::proto;
 use crate::read_write::{Encoding, NodeIterator};
 use crate::{AttributeDataType, CURRENT_VERSION};
-use cgmath::{EuclideanSpace, Point3, Vector3};
+use cgmath::Point3;
 use collision::Aabb3;
 use fnv::FnvHashMap;
 use s2::cell::Cell;
@@ -176,9 +176,7 @@ impl PointCloud for S2Cells {
             PointLocation::Obb(obb) => self.cells_in_obb(&obb, query.global_from_local.as_ref()),
             PointLocation::Frustum(frustum) => {
                 let world_from_clip = &frustum.from_frustum;
-                let points = CUBE_CORNERS
-                    .iter()
-                    .map(|p| Point3::from_vec(world_from_clip * p));
+                let points = CUBE_CORNERS.iter().map(|p| world_from_clip * p);
                 self.cells_in_convex_hull(points)
             }
             PointLocation::OrientedBeam(beam) => {
@@ -271,43 +269,43 @@ impl S2Cells {
 
 /// This is projected back with the inverse frustum matrix
 /// to find the corners of the frustum
-const CUBE_CORNERS: [Vector3<f64>; 8] = [
-    Vector3 {
+const CUBE_CORNERS: [Point3<f64>; 8] = [
+    Point3 {
         x: -1.0,
         y: -1.0,
         z: -1.0,
     },
-    Vector3 {
+    Point3 {
         x: -1.0,
         y: -1.0,
         z: 1.0,
     },
-    Vector3 {
+    Point3 {
         x: -1.0,
         y: 1.0,
         z: -1.0,
     },
-    Vector3 {
+    Point3 {
         x: -1.0,
         y: 1.0,
         z: 1.0,
     },
-    Vector3 {
+    Point3 {
         x: 1.0,
         y: -1.0,
         z: -1.0,
     },
-    Vector3 {
+    Point3 {
         x: 1.0,
         y: -1.0,
         z: 1.0,
     },
-    Vector3 {
+    Point3 {
         x: 1.0,
         y: 1.0,
         z: -1.0,
     },
-    Vector3 {
+    Point3 {
         x: 1.0,
         y: 1.0,
         z: 1.0,

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -5,7 +5,7 @@ use crate::math::{Isometry3, Obb};
 use crate::proto;
 use crate::read_write::{Encoding, NodeIterator};
 use crate::{AttributeDataType, CURRENT_VERSION};
-use cgmath::Point3;
+use cgmath::{Point3, Transform, Vector4};
 use collision::Aabb3;
 use fnv::FnvHashMap;
 use s2::cell::Cell;
@@ -175,8 +175,10 @@ impl PointCloud for S2Cells {
             }
             PointLocation::Obb(obb) => self.cells_in_obb(&obb, query.global_from_local.as_ref()),
             PointLocation::Frustum(frustum) => {
-                let world_from_clip = &frustum.from_frustum;
-                let points = CUBE_CORNERS.iter().map(|p| world_from_clip * p);
+                let world_from_clip = frustum.projection.inverse_transform().unwrap();
+                let points = CUBE_CORNERS
+                    .iter()
+                    .map(|p| Point3::from_homogeneous(world_from_clip * p));
                 self.cells_in_convex_hull(points)
             }
             PointLocation::OrientedBeam(beam) => {
@@ -269,45 +271,53 @@ impl S2Cells {
 
 /// This is projected back with the inverse frustum matrix
 /// to find the corners of the frustum
-const CUBE_CORNERS: [Point3<f64>; 8] = [
-    Point3 {
+const CUBE_CORNERS: [Vector4<f64>; 8] = [
+    Vector4 {
         x: -1.0,
         y: -1.0,
         z: -1.0,
+        w: 1.0,
     },
-    Point3 {
+    Vector4 {
         x: -1.0,
         y: -1.0,
         z: 1.0,
+        w: 1.0,
     },
-    Point3 {
+    Vector4 {
         x: -1.0,
         y: 1.0,
         z: -1.0,
+        w: 1.0,
     },
-    Point3 {
+    Vector4 {
         x: -1.0,
         y: 1.0,
         z: 1.0,
+        w: 1.0,
     },
-    Point3 {
+    Vector4 {
         x: 1.0,
         y: -1.0,
         z: -1.0,
+        w: 1.0,
     },
-    Point3 {
+    Vector4 {
         x: 1.0,
         y: -1.0,
         z: 1.0,
+        w: 1.0,
     },
-    Point3 {
+    Vector4 {
         x: 1.0,
         y: 1.0,
         z: -1.0,
+        w: 1.0,
     },
-    Point3 {
+    Vector4 {
         x: 1.0,
         y: 1.0,
         z: 1.0,
+        w: 1.0,
     },
 ];

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -241,8 +241,8 @@ impl S2Cells {
         global_from_query: Option<&Isometry3<f64>>,
     ) -> Vec<S2CellId> {
         let obb = match global_from_query {
-            Some(isometry) => Cow::Owned(Obb::new(
-                isometry * obb.query_from_obb(),
+            Some(g_from_q) => Cow::Owned(Obb::new(
+                g_from_q * obb.query_from_obb(),
                 *obb.half_extent(),
             )),
             None => Cow::Borrowed(obb),

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -5,7 +5,7 @@ use crate::math::{Isometry3, Obb};
 use crate::proto;
 use crate::read_write::{Encoding, NodeIterator};
 use crate::{AttributeDataType, CURRENT_VERSION};
-use cgmath::{Point3, Transform, Vector4};
+use cgmath::Point3;
 use collision::Aabb3;
 use fnv::FnvHashMap;
 use s2::cell::Cell;
@@ -175,11 +175,7 @@ impl PointCloud for S2Cells {
             }
             PointLocation::Obb(obb) => self.cells_in_obb(&obb, query.global_from_query.as_ref()),
             PointLocation::Frustum(frustum) => {
-                let query_from_clip = frustum.clip_from_query().inverse_transform().unwrap();
-                let points = CUBE_CORNERS
-                    .iter()
-                    .map(|p| Point3::from_homogeneous(query_from_clip * p));
-                self.cells_in_convex_hull(points)
+                self.cells_in_convex_hull(frustum.corners().iter().cloned())
             }
             PointLocation::OrientedBeam(beam) => {
                 self.cells_in_obb(&Obb::from(beam), query.global_from_query.as_ref())
@@ -241,10 +237,7 @@ impl S2Cells {
         global_from_query: Option<&Isometry3<f64>>,
     ) -> Vec<S2CellId> {
         let obb = match global_from_query {
-            Some(g_from_q) => Cow::Owned(Obb::new(
-                g_from_q * obb.query_from_obb(),
-                *obb.half_extent(),
-            )),
+            Some(g_from_q) => Cow::Owned(obb.new_transformed(g_from_q)),
             None => Cow::Borrowed(obb),
         };
         let points = obb.corners();
@@ -271,56 +264,3 @@ impl S2Cells {
             .collect()
     }
 }
-
-/// This is projected back with the inverse frustum matrix
-/// to find the corners of the frustum
-const CUBE_CORNERS: [Vector4<f64>; 8] = [
-    Vector4 {
-        x: -1.0,
-        y: -1.0,
-        z: -1.0,
-        w: 1.0,
-    },
-    Vector4 {
-        x: -1.0,
-        y: -1.0,
-        z: 1.0,
-        w: 1.0,
-    },
-    Vector4 {
-        x: -1.0,
-        y: 1.0,
-        z: -1.0,
-        w: 1.0,
-    },
-    Vector4 {
-        x: -1.0,
-        y: 1.0,
-        z: 1.0,
-        w: 1.0,
-    },
-    Vector4 {
-        x: 1.0,
-        y: -1.0,
-        z: -1.0,
-        w: 1.0,
-    },
-    Vector4 {
-        x: 1.0,
-        y: -1.0,
-        z: 1.0,
-        w: 1.0,
-    },
-    Vector4 {
-        x: 1.0,
-        y: 1.0,
-        z: -1.0,
-        w: 1.0,
-    },
-    Vector4 {
-        x: 1.0,
-        y: 1.0,
-        z: 1.0,
-        w: 1.0,
-    },
-];

--- a/xray/src/bin/build_xray_quadtree.rs
+++ b/xray/src/bin/build_xray_quadtree.rs
@@ -10,7 +10,7 @@ impl Extension for NullExtension {
     fn pre_init<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b> {
         app
     }
-    fn local_from_global(_: &clap::ArgMatches, _: &PointCloudClient) -> Option<Isometry3<f64>> {
+    fn query_from_global(_: &clap::ArgMatches, _: &PointCloudClient) -> Option<Isometry3<f64>> {
         None
     }
 }

--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 
 pub trait Extension {
     fn pre_init<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b>;
-    fn local_from_global(
+    fn query_from_global(
         matches: &clap::ArgMatches,
         point_cloud_client: &PointCloudClient,
     ) -> Option<Isometry3<f64>>;
@@ -148,11 +148,11 @@ pub fn run<T: Extension>(data_provider_factory: DataProviderFactory) {
     let point_cloud_client = PointCloudClient::new(&octree_locations, data_provider_factory)
         .expect("Could not create point cloud client.");
 
-    let local_from_global = T::local_from_global(&args, &point_cloud_client);
+    let query_from_global = T::query_from_global(&args, &point_cloud_client);
     build_xray_quadtree(
         &pool,
         &point_cloud_client,
-        &local_from_global,
+        &query_from_global,
         output_directory,
         &Tile {
             size_px: tile_size,


### PR DESCRIPTION
This PR improves the following:
- The frustum query now consists of an isometry describing the transformation from frustum to global coordinates and a perspective transformation.
- The frustum query got a unit test.
- The isometry now transforms points instead of vectors, which is in accordance with cgmath and nalgebra.
- Clarifies the transformation direction of struct variables of OBB, oriented beam, and frustum.