### PR TITLE
sdl_viewer: Fix bug causing empty stripes in terrain

### DIFF
--- a/sdl_viewer/src/terrain_drawer/layer.rs
+++ b/sdl_viewer/src/terrain_drawer/layer.rs
@@ -3,7 +3,7 @@ use crate::graphic::tiled_texture_loader::TiledTextureLoader;
 use crate::graphic::uniform::GlUniform;
 use crate::graphic::GlProgram;
 use crate::terrain_drawer::read_write::Metadata;
-use cgmath::{Decomposed, Matrix4, Vector2, Vector3, Zero};
+use cgmath::{Decomposed, Matrix4, Point3, Vector2, Vector3};
 use image::{ImageBuffer, LumaA, Rgba};
 use point_viewer::math::Isometry3;
 use std::convert::TryInto;
@@ -50,7 +50,7 @@ impl TerrainLayer {
 
         // Initial terrain pos
         let terrain_pos: Vector2<i64> =
-            grid_coordinates.terrain_pos_for_camera_pos(Vector3::zero());
+            grid_coordinates.terrain_pos_for_camera_pos(Point3::new(0.0, 0.0, 0.0));
         let u_terrain_pos = GlUniform::new(&program, "terrain_pos", terrain_pos.cast().unwrap());
 
         let height_initial = height_tiles.load(
@@ -100,7 +100,7 @@ impl TerrainLayer {
     // Only fetch the "L" shape that is needed, as separate horizontal and vertical strips.
     // Don't get confused, the horizontal strip is determined by the movement in y direction and
     // the vertical strip is determined by the movement in x direction.
-    pub fn update(&mut self, cur_world_pos: Vector3<f64>) {
+    pub fn update(&mut self, cur_world_pos: Point3<f64>) {
         let cur_pos = self
             .grid_coordinates
             .terrain_pos_for_camera_pos(cur_world_pos);
@@ -219,7 +219,7 @@ impl GridCoordinateFrame {
 
     /// Returns the terrain pos (i.e. the coordinate of the lower corner of the terrain) for
     /// a given camera position (in the world coordinate system).
-    fn terrain_pos_for_camera_pos(&self, world_pos: Vector3<f64>) -> Vector2<i64> {
+    fn terrain_pos_for_camera_pos(&self, world_pos: Point3<f64>) -> Vector2<i64> {
         let local_pos = &self.terrain_from_world * &world_pos;
         let x = ((local_pos.x - self.u_origin.value.x) / self.u_resolution_m.value).floor();
         let y = ((local_pos.y - self.u_origin.value.y) / self.u_resolution_m.value).floor();


### PR DESCRIPTION
I noticed that when moving right, one column of values would get skipped, and similarly when moving up. The fix is that terrain_pos should still contain the previous position, not the one after moving, when making calls to `load()`.