### PR TITLE
Speed up attribute queries.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod s2_cells;
 
 use cgmath::Vector3;
 use errors::{ErrorKind, Result};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::convert::{TryFrom, TryInto};
 
 // Version 9 -> 10: Change in NodeId proto from level (u8) and index (u64) to high (u64) and low
@@ -60,6 +60,21 @@ pub fn attribute_extension(attribute: &str) -> &str {
         "color" => "rgb",
         _ => attribute,
     }
+}
+
+fn attribute_data_types_from(
+    attributes: &[&str],
+    data_types: &HashMap<String, AttributeDataType>,
+) -> Result<HashMap<String, AttributeDataType>> {
+    attributes
+        .iter()
+        .map(|a| {
+            data_types
+                .get(*a)
+                .map(|d| (a.to_string(), *d))
+                .ok_or_else(|| format!("Data type for attribute '{}' not found.", a).into())
+        })
+        .collect::<Result<HashMap<String, AttributeDataType>>>()
 }
 
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,19 +62,22 @@ pub fn attribute_extension(attribute: &str) -> &str {
     }
 }
 
-fn attribute_data_types_from(
-    attributes: &[&str],
-    data_types: &HashMap<String, AttributeDataType>,
-) -> Result<HashMap<String, AttributeDataType>> {
-    attributes
-        .iter()
-        .map(|a| {
-            data_types
-                .get(*a)
-                .map(|d| (a.to_string(), *d))
-                .ok_or_else(|| format!("Data type for attribute '{}' not found.", a).into())
-        })
-        .collect()
+trait PointCloudMeta {
+    fn attribute_data_types(&self) -> &HashMap<String, AttributeDataType>;
+    fn attribute_data_types_for(
+        &self,
+        attributes: &[&str],
+    ) -> Result<HashMap<String, AttributeDataType>> {
+        attributes
+            .iter()
+            .map(|a| {
+                self.attribute_data_types()
+                    .get(*a)
+                    .map(|d| (a.to_string(), *d))
+                    .ok_or_else(|| format!("Data type for attribute '{}' not found.", a).into())
+            })
+            .collect()
+    }
 }
 
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ fn attribute_data_types_from(
                 .map(|d| (a.to_string(), *d))
                 .ok_or_else(|| format!("Data type for attribute '{}' not found.", a).into())
         })
-        .collect::<Result<HashMap<String, AttributeDataType>>>()
+        .collect()
 }
 
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]

--- a/src/octree/generation.rs
+++ b/src/octree/generation.rs
@@ -21,9 +21,7 @@ use crate::read_write::{
     attempt_increasing_rlimit_to_max, Encoding, NodeIterator, NodeWriter, OpenMode, PlyIterator,
     PositionEncoding, RawNodeWriter,
 };
-use crate::{
-    attribute_data_types_from, AttributeDataType, NumberOfPoints, PointsBatch, NUM_POINTS_PER_BATCH,
-};
+use crate::{AttributeDataType, NumberOfPoints, PointCloudMeta, PointsBatch, NUM_POINTS_PER_BATCH};
 use cgmath::{EuclideanSpace, Point3, Vector3};
 use collision::{Aabb, Aabb3};
 use fnv::{FnvHashMap, FnvHashSet};
@@ -315,7 +313,7 @@ pub fn build_octree(
         resolution,
         ..Default::default()
     };
-    let query_attributes = &attribute_data_types_from(attributes, &octree_meta.attributes).unwrap();
+    let query_attributes = &octree_meta.attribute_data_types_for(attributes).unwrap();
     let octree_data_provider = OnDiskDataProvider {
         directory: output_directory.as_ref().to_path_buf(),
     };

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -17,7 +17,7 @@ use crate::iterator::{FilteredIterator, PointCloud, PointQuery};
 use crate::math::Cube;
 use crate::proto;
 use crate::read_write::{Encoding, NodeIterator, PositionEncoding};
-use crate::{attribute_data_types_from, AttributeDataType, CURRENT_VERSION};
+use crate::{AttributeDataType, PointCloudMeta, CURRENT_VERSION};
 use cgmath::{EuclideanSpace, Matrix4, Point3};
 use collision::{Aabb, Aabb3, Bound, Relation};
 use fnv::FnvHashMap;
@@ -43,6 +43,12 @@ pub struct OctreeMeta {
     pub resolution: f64,
     pub bounding_box: Aabb3<f64>,
     attributes: HashMap<String, AttributeDataType>,
+}
+
+impl PointCloudMeta for OctreeMeta {
+    fn attribute_data_types(&self) -> &HashMap<String, AttributeDataType> {
+        &self.attributes
+    }
 }
 
 impl Default for OctreeMeta {
@@ -324,7 +330,7 @@ impl PointCloud for Octree {
         let culling = query.get_point_culling();
         let node_iterator = NodeIterator::from_data_provider(
             &*self.data_provider,
-            &attribute_data_types_from(&query.attributes, &self.meta.attributes)?,
+            &self.meta.attribute_data_types_for(&query.attributes)?,
             self.meta.encoding_for_node(node_id),
             &node_id,
             self.nodes[&node_id].num_points as usize,

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -4,7 +4,7 @@ use crate::iterator::{FilteredIterator, PointCloud, PointLocation, PointQuery};
 use crate::math::{Isometry3, Obb};
 use crate::proto;
 use crate::read_write::{Encoding, NodeIterator};
-use crate::{attribute_data_types_from, AttributeDataType, CURRENT_VERSION};
+use crate::{AttributeDataType, PointCloudMeta, CURRENT_VERSION};
 use cgmath::Point3;
 use collision::Aabb3;
 use fnv::FnvHashMap;
@@ -41,6 +41,12 @@ pub struct S2Meta {
     cells: FnvHashMap<CellID, S2CellMeta>,
     attributes: HashMap<String, AttributeDataType>,
     bounding_box: Aabb3<f64>,
+}
+
+impl PointCloudMeta for S2Meta {
+    fn attribute_data_types(&self) -> &HashMap<String, AttributeDataType> {
+        &self.attributes
+    }
 }
 
 impl S2Meta {
@@ -197,7 +203,7 @@ impl PointCloud for S2Cells {
         let num_points = self.meta.cells[&node_id.0].num_points as usize;
         let node_iterator = NodeIterator::from_data_provider(
             &*self.data_provider,
-            &attribute_data_types_from(&query.attributes, &self.meta.attributes)?,
+            &self.meta.attribute_data_types_for(&query.attributes)?,
             self.encoding_for_node(node_id),
             &node_id,
             num_points,

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -4,7 +4,7 @@ use crate::iterator::{FilteredIterator, PointCloud, PointLocation, PointQuery};
 use crate::math::{Isometry3, Obb};
 use crate::proto;
 use crate::read_write::{Encoding, NodeIterator};
-use crate::{AttributeDataType, CURRENT_VERSION};
+use crate::{attribute_data_types_from, AttributeDataType, CURRENT_VERSION};
 use cgmath::Point3;
 use collision::Aabb3;
 use fnv::FnvHashMap;
@@ -197,7 +197,7 @@ impl PointCloud for S2Cells {
         let num_points = self.meta.cells[&node_id.0].num_points as usize;
         let node_iterator = NodeIterator::from_data_provider(
             &*self.data_provider,
-            &query.attributes,
+            &attribute_data_types_from(&query.attributes, &self.meta.attributes)?,
             self.encoding_for_node(node_id),
             &node_id,
             num_points,


### PR DESCRIPTION
This fixes a regression introduced with #367, where the meta data of point clouds was queried for each node. This speeds up queries by about 10x - 20x again.