### PR TITLE
Support geometry shader in sdl_viewer

### DIFF
--- a/sdl_viewer/src/box_drawer.rs
+++ b/sdl_viewer/src/box_drawer.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::graphic::{GlBuffer, GlProgram, GlVertexArray};
+use crate::graphic::{GlBuffer, GlProgram, GlProgramBuilder, GlVertexArray};
 use crate::opengl;
 use crate::opengl::types::{GLboolean, GLint, GLsizeiptr, GLuint};
 use cgmath::{EuclideanSpace, Matrix, Matrix4};
@@ -41,11 +41,10 @@ pub struct BoxDrawer {
 
 impl BoxDrawer {
     pub fn new(gl: &Rc<opengl::Gl>) -> Self {
-        let outline_program = GlProgram::new(
-            Rc::clone(gl),
-            VERTEX_SHADER_OUTLINED_BOX,
-            FRAGMENT_SHADER_OUTLINED_BOX,
-        );
+        let outline_program =
+            GlProgramBuilder::new_with_vertex_shader(Rc::clone(gl), VERTEX_SHADER_OUTLINED_BOX)
+                .fragment_shader(FRAGMENT_SHADER_OUTLINED_BOX)
+                .build();
         let u_transform;
         let u_color;
 

--- a/sdl_viewer/src/glhelper.rs
+++ b/sdl_viewer/src/glhelper.rs
@@ -57,14 +57,21 @@ pub fn link_program(
     gl: &opengl::Gl,
     vertex_shader_id: GLuint,
     fragment_shader_id: GLuint,
+    geometry_shader_id: Option<GLuint>,
 ) -> GLuint {
     unsafe {
         let program = gl.CreateProgram();
         gl.AttachShader(program, vertex_shader_id);
         gl.AttachShader(program, fragment_shader_id);
+        if let Some(id) = geometry_shader_id {
+            gl.AttachShader(program, id)
+        };
         gl.LinkProgram(program);
         gl.DetachShader(program, vertex_shader_id);
         gl.DetachShader(program, fragment_shader_id);
+        if let Some(id) = geometry_shader_id {
+            gl.DetachShader(program, id)
+        };
 
         let mut status = i32::from(opengl::FALSE);
         gl.GetProgramiv(program, opengl::LINK_STATUS, &mut status);

--- a/sdl_viewer/src/graphic/mod.rs
+++ b/sdl_viewer/src/graphic/mod.rs
@@ -14,66 +14,19 @@
 
 //! Higher level abstractions around core OpenGL concepts.
 
-use crate::glhelper::{compile_shader, link_program};
 use crate::opengl::types::GLuint;
 use crate::opengl::{self, Gl};
 use std::rc::Rc;
-use std::str;
 
-pub mod moving_window_texture;
+mod moving_window_texture;
+mod program;
+mod uniform;
+// This is namespaced as it doesn't deal with Gl directly
 pub mod tiled_texture_loader;
-pub mod uniform;
 
-pub struct GlProgram {
-    pub gl: Rc<Gl>,
-    pub id: GLuint,
-}
-
-impl GlProgram {
-    pub fn new(gl: Rc<opengl::Gl>, vertex_shader: &str, fragment_shader: &str) -> Self {
-        let vertex_shader_id = compile_shader(&*gl, vertex_shader, opengl::VERTEX_SHADER);
-        let fragment_shader_id = compile_shader(&*gl, fragment_shader, opengl::FRAGMENT_SHADER);
-        let id = link_program(&*gl, vertex_shader_id, fragment_shader_id, None);
-
-        // TODO(hrapp): Pull out some saner abstractions around program compilation.
-        unsafe {
-            gl.DeleteShader(vertex_shader_id);
-            gl.DeleteShader(fragment_shader_id);
-        }
-        GlProgram { gl, id }
-    }
-
-    pub fn new_with_geometry_shader(
-        gl: Rc<opengl::Gl>,
-        vertex_shader: &str,
-        fragment_shader: &str,
-        geometry_shader: &str,
-    ) -> Self {
-        let vertex_shader_id = compile_shader(&*gl, vertex_shader, opengl::VERTEX_SHADER);
-        let fragment_shader_id = compile_shader(&*gl, fragment_shader, opengl::FRAGMENT_SHADER);
-        let geometry_shader_id = compile_shader(&*gl, geometry_shader, opengl::GEOMETRY_SHADER);
-        let id = link_program(
-            &*gl,
-            vertex_shader_id,
-            fragment_shader_id,
-            Some(geometry_shader_id),
-        );
-        unsafe {
-            gl.DeleteShader(vertex_shader_id);
-            gl.DeleteShader(fragment_shader_id);
-            gl.DeleteShader(geometry_shader_id);
-        }
-        GlProgram { gl, id }
-    }
-}
-
-impl Drop for GlProgram {
-    fn drop(&mut self) {
-        unsafe {
-            self.gl.DeleteProgram(self.id);
-        }
-    }
-}
+pub use moving_window_texture::GlMovingWindowTexture;
+pub use program::{GlProgram, GlProgramBuilder};
+pub use uniform::GlUniform;
 
 pub struct GlBuffer {
     gl: Rc<Gl>,

--- a/sdl_viewer/src/graphic/mod.rs
+++ b/sdl_viewer/src/graphic/mod.rs
@@ -33,12 +33,35 @@ impl GlProgram {
     pub fn new(gl: Rc<opengl::Gl>, vertex_shader: &str, fragment_shader: &str) -> Self {
         let vertex_shader_id = compile_shader(&*gl, vertex_shader, opengl::VERTEX_SHADER);
         let fragment_shader_id = compile_shader(&*gl, fragment_shader, opengl::FRAGMENT_SHADER);
-        let id = link_program(&*gl, vertex_shader_id, fragment_shader_id);
+        let id = link_program(&*gl, vertex_shader_id, fragment_shader_id, None);
 
         // TODO(hrapp): Pull out some saner abstractions around program compilation.
         unsafe {
             gl.DeleteShader(vertex_shader_id);
             gl.DeleteShader(fragment_shader_id);
+        }
+        GlProgram { gl, id }
+    }
+
+    pub fn new_with_geometry_shader(
+        gl: Rc<opengl::Gl>,
+        vertex_shader: &str,
+        fragment_shader: &str,
+        geometry_shader: &str,
+    ) -> Self {
+        let vertex_shader_id = compile_shader(&*gl, vertex_shader, opengl::VERTEX_SHADER);
+        let fragment_shader_id = compile_shader(&*gl, fragment_shader, opengl::FRAGMENT_SHADER);
+        let geometry_shader_id = compile_shader(&*gl, geometry_shader, opengl::GEOMETRY_SHADER);
+        let id = link_program(
+            &*gl,
+            vertex_shader_id,
+            fragment_shader_id,
+            Some(geometry_shader_id),
+        );
+        unsafe {
+            gl.DeleteShader(vertex_shader_id);
+            gl.DeleteShader(fragment_shader_id);
+            gl.DeleteShader(geometry_shader_id);
         }
         GlProgram { gl, id }
     }

--- a/sdl_viewer/src/graphic/program.rs
+++ b/sdl_viewer/src/graphic/program.rs
@@ -1,30 +1,71 @@
-// Copyright 2017 Joseph A Mark <sjeohp@gmail.com>
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
-// and associated documentation files (the "Software"), to deal in the Software without
-// restriction, including without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-// This code here was extracted from the glhelper crate. We could not depend on it directly, since
-// we generate our own gl module which cannot be easily injected.
-
 use crate::opengl;
 use crate::opengl::types::{GLchar, GLenum, GLint, GLuint};
 use std::ffi::CString;
 use std::ptr;
+use std::rc::Rc;
 use std::str;
 
-pub fn compile_shader(gl: &opengl::Gl, code: &str, kind: GLenum) -> GLuint {
+pub struct GlProgramBuilder<'a> {
+    gl: Rc<opengl::Gl>,
+    vertex_shader: &'a str,
+    geometry_shader: Option<&'a str>,
+    fragment_shader: Option<&'a str>,
+}
+
+impl<'a> GlProgramBuilder<'a> {
+    pub fn new_with_vertex_shader(gl: Rc<opengl::Gl>, vertex_shader: &'a str) -> Self {
+        GlProgramBuilder {
+            gl,
+            vertex_shader,
+            geometry_shader: None,
+            fragment_shader: None,
+        }
+    }
+    pub fn geometry_shader(mut self, geometry_shader: &'a str) -> Self {
+        self.geometry_shader = Some(geometry_shader);
+        self
+    }
+    pub fn fragment_shader(mut self, fragment_shader: &'a str) -> Self {
+        self.fragment_shader = Some(fragment_shader);
+        self
+    }
+    pub fn build(self) -> GlProgram {
+        let vertex_shader_id = compile_shader(&self.gl, self.vertex_shader, opengl::VERTEX_SHADER);
+        let geometry_shader_id = self
+            .geometry_shader
+            .map(|gs| compile_shader(&self.gl, gs, opengl::GEOMETRY_SHADER));
+        let fragment_shader_id = self
+            .fragment_shader
+            .map(|fs| compile_shader(&self.gl, fs, opengl::FRAGMENT_SHADER));
+        let id = link_program(
+            &self.gl,
+            vertex_shader_id,
+            geometry_shader_id,
+            fragment_shader_id,
+        );
+        unsafe {
+            self.gl.DeleteShader(vertex_shader_id);
+            geometry_shader_id.map(|sid| self.gl.DeleteShader(sid));
+            fragment_shader_id.map(|sid| self.gl.DeleteShader(sid));
+        }
+        GlProgram { gl: self.gl, id }
+    }
+}
+
+pub struct GlProgram {
+    pub gl: Rc<opengl::Gl>,
+    pub id: GLuint,
+}
+
+impl Drop for GlProgram {
+    fn drop(&mut self) {
+        unsafe {
+            self.gl.DeleteProgram(self.id);
+        }
+    }
+}
+
+fn compile_shader(gl: &opengl::Gl, code: &str, kind: GLenum) -> GLuint {
     let shader;
     unsafe {
         shader = gl.CreateShader(kind);
@@ -53,23 +94,27 @@ pub fn compile_shader(gl: &opengl::Gl, code: &str, kind: GLenum) -> GLuint {
     shader
 }
 
-pub fn link_program(
+fn link_program(
     gl: &opengl::Gl,
     vertex_shader_id: GLuint,
-    fragment_shader_id: GLuint,
     geometry_shader_id: Option<GLuint>,
+    fragment_shader_id: Option<GLuint>,
 ) -> GLuint {
     unsafe {
         let program = gl.CreateProgram();
         gl.AttachShader(program, vertex_shader_id);
-        gl.AttachShader(program, fragment_shader_id);
         if let Some(id) = geometry_shader_id {
             gl.AttachShader(program, id)
         };
+        if let Some(id) = fragment_shader_id {
+            gl.AttachShader(program, id);
+        }
         gl.LinkProgram(program);
         gl.DetachShader(program, vertex_shader_id);
-        gl.DetachShader(program, fragment_shader_id);
         if let Some(id) = geometry_shader_id {
+            gl.DetachShader(program, id)
+        };
+        if let Some(id) = fragment_shader_id {
             gl.DetachShader(program, id)
         };
 

--- a/sdl_viewer/src/graphic/program.rs
+++ b/sdl_viewer/src/graphic/program.rs
@@ -44,9 +44,9 @@ impl<'a> GlProgramBuilder<'a> {
         }
         let id = link_program(&self.gl, &shader_ids);
         unsafe {
-            shader_ids
-                .iter()
-                .for_each(|shader_id| self.gl.DeleteShader(*shader_id));
+            for shader_id in shader_ids.iter() {
+                self.gl.DeleteShader(*shader_id);
+            }
         }
         GlProgram { gl: self.gl, id }
     }
@@ -97,13 +97,13 @@ fn compile_shader(gl: &opengl::Gl, code: &str, kind: GLenum) -> GLuint {
 fn link_program(gl: &opengl::Gl, shader_ids: &[GLuint]) -> GLuint {
     unsafe {
         let program = gl.CreateProgram();
-        shader_ids
-            .iter()
-            .for_each(|shader_id| gl.AttachShader(program, *shader_id));
+        for shader_id in shader_ids.iter() {
+            gl.AttachShader(program, *shader_id);
+        }
         gl.LinkProgram(program);
-        shader_ids
-            .iter()
-            .for_each(|shader_id| gl.DetachShader(program, *shader_id));
+        for shader_id in shader_ids.iter() {
+            gl.DetachShader(program, *shader_id);
+        }
 
         let mut status = i32::from(opengl::FALSE);
         gl.GetProgramiv(program, opengl::LINK_STATUS, &mut status);

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -23,7 +23,6 @@ macro_rules! c_str {
 }
 
 mod camera;
-mod glhelper;
 #[allow(
     non_upper_case_globals,
     clippy::too_many_arguments,

--- a/sdl_viewer/src/node_drawer.rs
+++ b/sdl_viewer/src/node_drawer.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::graphic::{GlBuffer, GlProgram, GlVertexArray};
+use crate::graphic::{GlBuffer, GlProgram, GlProgramBuilder, GlVertexArray};
 use crate::opengl;
 use crate::opengl::types::{GLboolean, GLint, GLsizeiptr, GLuint};
 use cgmath::{Array, Matrix, Matrix4};
@@ -62,7 +62,9 @@ pub struct NodeDrawer {
 impl NodeDrawer {
     pub fn new(gl: &Rc<opengl::Gl>) -> Self {
         let create_program = |vertex_shader: &str| {
-            let program = GlProgram::new(Rc::clone(gl), vertex_shader, FRAGMENT_SHADER);
+            let program = GlProgramBuilder::new_with_vertex_shader(Rc::clone(gl), vertex_shader)
+                .fragment_shader(FRAGMENT_SHADER)
+                .build();
             let u_world_to_gl;
             let u_edge_length;
             let u_size;

--- a/sdl_viewer/src/terrain_drawer/layer.rs
+++ b/sdl_viewer/src/terrain_drawer/layer.rs
@@ -1,7 +1,5 @@
-use crate::graphic::moving_window_texture::GlMovingWindowTexture;
 use crate::graphic::tiled_texture_loader::TiledTextureLoader;
-use crate::graphic::uniform::GlUniform;
-use crate::graphic::GlProgram;
+use crate::graphic::{GlMovingWindowTexture, GlProgram, GlUniform};
 use crate::terrain_drawer::read_write::Metadata;
 use cgmath::{Decomposed, Matrix4, Point3, Vector2, Vector3};
 use image::{ImageBuffer, LumaA, Rgba};


### PR DESCRIPTION
This extends the code for compiling and linking GLSL programs to allow a geometry shader stage.
Also reexports `GlUniform` and `GlMovingWindowTexture` from the `graphic` module.