### PR TITLE
sdl_viewer: Bind texture in submit()

### DIFF
--- a/sdl_viewer/src/graphic/moving_window_texture.rs
+++ b/sdl_viewer/src/graphic/moving_window_texture.rs
@@ -330,7 +330,10 @@ where
     /// Updates the offset and binds the texture
     pub fn submit(&self) {
         unsafe {
+            // The purpose of texture units is to allow us to use more than 1 texture in our shaders.
             self.gl.ActiveTexture(opengl::TEXTURE0 + self.texture_unit);
+            // After activating a texture unit, a subsequent BindTexture call will bind that
+            // texture to the currently active texture unit. 
             self.gl.BindTexture(opengl::TEXTURE_2D, self.id);
         }
         self.u_texture_offset.submit();

--- a/sdl_viewer/src/graphic/moving_window_texture.rs
+++ b/sdl_viewer/src/graphic/moving_window_texture.rs
@@ -329,6 +329,10 @@ where
 
     /// Updates the offset and binds the texture
     pub fn submit(&self) {
+        unsafe {
+            self.gl.ActiveTexture(opengl::TEXTURE0 + self.texture_unit);
+            self.gl.BindTexture(opengl::TEXTURE_2D, self.id);
+        }
         self.u_texture_offset.submit();
     }
 }

--- a/sdl_viewer/src/graphic/moving_window_texture.rs
+++ b/sdl_viewer/src/graphic/moving_window_texture.rs
@@ -333,7 +333,7 @@ where
             // The purpose of texture units is to allow us to use more than 1 texture in our shaders.
             self.gl.ActiveTexture(opengl::TEXTURE0 + self.texture_unit);
             // After activating a texture unit, a subsequent BindTexture call will bind that
-            // texture to the currently active texture unit. 
+            // texture to the currently active texture unit.
             self.gl.BindTexture(opengl::TEXTURE_2D, self.id);
         }
         self.u_texture_offset.submit();


### PR DESCRIPTION
This allows several instances of `GlMovingWindowTexture` to coexist.