### PR TITLE
Move corners method outside culling, fix isometry identity constructor.

### DIFF
--- a/benches/generate_and_query/main.rs
+++ b/benches/generate_and_query/main.rs
@@ -291,7 +291,7 @@ fn check_frustum_query_equality() {
 #[test]
 fn check_obb_query_equality() {
     let (args, s2, oct, points) = setup();
-    let obb = Obb::new(Isometry3::zero(), Vector3::new(15.0, 15.0, 15.0));
+    let obb = Obb::new(Isometry3::one(), Vector3::new(15.0, 15.0, 15.0));
     let query = PointQuery {
         attributes: vec!["color"],
         location: PointLocation::Obb(obb),

--- a/src/math.rs
+++ b/src/math.rs
@@ -271,9 +271,9 @@ impl<S: BaseFloat> Isometry3<S> {
 
 #[derive(Debug, Clone)]
 pub struct Obb<S> {
-    pub query_from_obb: Isometry3<S>,
+    query_from_obb: Isometry3<S>,
     obb_from_query: Isometry3<S>,
-    pub half_extent: Vector3<S>,
+    half_extent: Vector3<S>,
     corners: [Point3<S>; 8],
     separating_axes: Vec<Vector3<S>>,
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -20,6 +20,8 @@ use collision::{Aabb, Aabb3, Contains, Relation};
 use nav_types::{ECEF, WGS84};
 use num_traits::identities::One;
 use num_traits::Float;
+use s2::point::Point as S2Point;
+use s2::rect::Rect as S2Rect;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::ops::Mul;
@@ -50,6 +52,9 @@ where
     // TODO(catevita): return Relation
     fn intersects_aabb3(&self, aabb: &Aabb3<S>) -> bool;
     fn transformed(&self, global_from_query: &Isometry3<S>) -> Box<dyn PointCulling<S>>;
+}
+
+pub trait Cuboid<S> {
     fn corners(&self) -> [Point3<S>; 8];
 }
 
@@ -67,6 +72,12 @@ where
     fn transformed(&self, global_from_query: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
         Obb::from(self).transformed(global_from_query)
     }
+}
+
+impl<S> Cuboid<S> for Aabb3<S>
+where
+    S: BaseFloat,
+{
     fn corners(&self) -> [Point3<S>; 8] {
         self.to_corners()
     }
@@ -88,18 +99,6 @@ where
     }
     fn transformed(&self, _: &Isometry3<S>) -> Box<dyn PointCulling<S>> {
         Box::new(Self {})
-    }
-    fn corners(&self) -> [Point3<S>; 8] {
-        [
-            Point3::new(S::neg_infinity(), S::neg_infinity(), S::neg_infinity()),
-            Point3::new(S::neg_infinity(), S::neg_infinity(), S::infinity()),
-            Point3::new(S::neg_infinity(), S::infinity(), S::neg_infinity()),
-            Point3::new(S::neg_infinity(), S::infinity(), S::infinity()),
-            Point3::new(S::infinity(), S::neg_infinity(), S::neg_infinity()),
-            Point3::new(S::infinity(), S::neg_infinity(), S::infinity()),
-            Point3::new(S::infinity(), S::infinity(), S::neg_infinity()),
-            Point3::new(S::infinity(), S::infinity(), S::infinity()),
-        ]
     }
 }
 #[derive(Debug, Clone)]
@@ -256,9 +255,10 @@ impl<S: BaseFloat> Isometry3<S> {
         }
     }
 
-    pub fn zero() -> Self {
+    /// Returns the identity transformation.
+    pub fn one() -> Self {
         Isometry3 {
-            rotation: Quaternion::zero(),
+            rotation: Quaternion::one(),
             translation: Vector3::zero(),
         }
     }
@@ -273,9 +273,9 @@ impl<S: BaseFloat> Isometry3<S> {
 
 #[derive(Debug, Clone)]
 pub struct Obb<S> {
-    query_from_obb: Isometry3<S>,
+    pub query_from_obb: Isometry3<S>,
     obb_from_query: Isometry3<S>,
-    half_extent: Vector3<S>,
+    pub half_extent: Vector3<S>,
     corners: [Point3<S>; 8],
     separating_axes: Vec<Vector3<S>>,
 }
@@ -377,6 +377,12 @@ where
             self.half_extent,
         ))
     }
+}
+
+impl<S> Cuboid<S> for Obb<S>
+where
+    S: BaseFloat,
+{
     fn corners(&self) -> [Point3<S>; 8] {
         self.corners
     }
@@ -435,6 +441,12 @@ where
             self.clip_from_eye,
         ))
     }
+}
+
+impl<S> Cuboid<S> for Frustum<S>
+where
+    S: BaseFloat,
+{
     fn corners(&self) -> [Point3<S>; 8] {
         let corner_from = |x, y, z| self.query_from_clip.transform_point(Point3::new(x, y, z));
         [

--- a/src/math.rs
+++ b/src/math.rs
@@ -20,8 +20,6 @@ use collision::{Aabb, Aabb3, Contains, Relation};
 use nav_types::{ECEF, WGS84};
 use num_traits::identities::One;
 use num_traits::Float;
-use s2::point::Point as S2Point;
-use s2::rect::Rect as S2Rect;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::ops::Mul;


### PR DESCRIPTION
This will simplify the implementation of cullings without corners.