### PR TITLE
Remove global_from_query transform from query.

### DIFF
--- a/benches/generate_and_query/main.rs
+++ b/benches/generate_and_query/main.rs
@@ -7,7 +7,7 @@ use lazy_static::lazy_static;
 use num_integer::div_ceil;
 use point_viewer::data_provider::{DataProvider, OnDiskDataProvider};
 use point_viewer::iterator::{PointCloud, PointLocation, PointQuery};
-use point_viewer::math::{Frustum, Isometry3, Obb};
+use point_viewer::math::{Frustum, Obb};
 use point_viewer::octree::{build_octree, Octree};
 use point_viewer::read_write::{Encoding, NodeWriter, OpenMode, RawNodeWriter, S2Splitter};
 use point_viewer::s2_cells::S2Cells;
@@ -245,7 +245,6 @@ fn check_all_query_equality() {
     let query = PointQuery {
         attributes: vec!["color"],
         location: PointLocation::AllPoints,
-        global_from_query: None,
     };
     let points_s2 = query_and_sort(&s2, &query, args.batch_size);
     let points_oct = query_and_sort(&oct, &query, args.batch_size);
@@ -259,7 +258,6 @@ fn check_box_query_equality() {
     let query = PointQuery {
         attributes: vec!["color"],
         location: PointLocation::Aabb(bbox),
-        global_from_query: None,
     };
     let points_s2 = query_and_sort(&s2, &query, args.batch_size);
     let points_oct = query_and_sort(&oct, &query, args.batch_size);
@@ -281,7 +279,6 @@ fn check_frustum_query_equality() {
     let query = PointQuery {
         attributes: vec!["color"],
         location: PointLocation::Frustum(frustum),
-        global_from_query: None,
     };
     let points_s2 = query_and_sort(&s2, &query, args.batch_size);
     let points_oct = query_and_sort(&oct, &query, args.batch_size);
@@ -291,11 +288,13 @@ fn check_frustum_query_equality() {
 #[test]
 fn check_obb_query_equality() {
     let (args, s2, oct, points) = setup();
-    let obb = Obb::new(Isometry3::one(), Vector3::new(15.0, 15.0, 15.0));
+    let obb = Obb::new(
+        points.ecef_from_local().clone(),
+        Vector3::new(15.0, 15.0, 15.0),
+    );
     let query = PointQuery {
         attributes: vec!["color"],
         location: PointLocation::Obb(obb),
-        global_from_query: Some(points.ecef_from_local().clone()),
     };
     let points_oct = query_and_sort(&oct, &query, args.batch_size);
     let points_s2 = query_and_sort(&s2, &query, args.batch_size);

--- a/point_cloud_client/src/bin/test.rs
+++ b/point_cloud_client/src/bin/test.rs
@@ -72,7 +72,6 @@ fn main() {
     let point_location = PointQuery {
         attributes: vec!["color", "intensity"],
         location: PointLocation::Aabb(Aabb3::new(args.min, args.max)),
-        global_from_query: None,
     };
     let mut point_count: usize = 0;
     let mut print_count: usize = 1;

--- a/point_viewer_grpc/src/bin/octree_benchmark.rs
+++ b/point_viewer_grpc/src/bin/octree_benchmark.rs
@@ -102,7 +102,6 @@ fn server_benchmark(
     let all_points = PointQuery {
         attributes: vec!["color", "intensity"],
         location: PointLocation::AllPoints,
-        global_from_query: None,
     };
     let octree_slice: &[Octree] = std::slice::from_ref(&octree);
     let mut parallel_iterator = ParallelIterator::new(

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -297,7 +297,6 @@ impl OctreeService {
                 let point_query = PointQuery {
                     attributes: vec!["color", "intensity"],
                     location,
-                    global_from_query: None,
                 };
                 let mut parallel_iterator = ParallelIterator::new(
                     octree_slice,

--- a/src/math.rs
+++ b/src/math.rs
@@ -51,10 +51,7 @@ where
     fn intersects_aabb3(&self, aabb: &Aabb3<S>) -> bool;
 }
 
-pub trait Cuboid<S>
-where
-    S: BaseFloat,
-{
+pub trait Cuboid<S> {
     fn corners(&self) -> [Point3<S>; 8];
 }
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -49,6 +49,12 @@ where
     fn contains(&self, point: &Point3<S>) -> bool;
     // TODO(catevita): return Relation
     fn intersects_aabb3(&self, aabb: &Aabb3<S>) -> bool;
+}
+
+pub trait Cuboid<S>
+where
+    S: BaseFloat,
+{
     fn corners(&self) -> [Point3<S>; 8];
 }
 
@@ -63,6 +69,12 @@ where
         let separating_axes = &[Vector3::unit_x(), Vector3::unit_y(), Vector3::unit_z()];
         intersects_aabb3(&self.to_corners(), separating_axes, aabb)
     }
+}
+
+impl<S> Cuboid<S> for Aabb3<S>
+where
+    S: BaseFloat,
+{
     fn corners(&self) -> [Point3<S>; 8] {
         self.to_corners()
     }
@@ -419,6 +431,12 @@ where
             Relation::Out => false,
         }
     }
+}
+
+impl<S> Cuboid<S> for Frustum<S>
+where
+    S: BaseFloat,
+{
     fn corners(&self) -> [Point3<S>; 8] {
         let corner_from = |x, y, z| self.query_from_clip.transform_point(Point3::new(x, y, z));
         [

--- a/src/octree/octree_test.rs
+++ b/src/octree/octree_test.rs
@@ -117,7 +117,6 @@ mod tests {
         let location = PointQuery {
             attributes: vec!["color"],
             location: PointLocation::AllPoints,
-            global_from_query: None,
         };
         let octree_slice: &[Octree] = std::slice::from_ref(&octree);
         let mut parallel_iterator = ParallelIterator::new(
@@ -175,7 +174,6 @@ mod tests {
         let location = PointQuery {
             attributes: vec!["color"],
             location: PointLocation::AllPoints,
-            global_from_query: None,
         };
 
         let octree_slice: &[Octree] = std::slice::from_ref(&octree);
@@ -222,7 +220,6 @@ mod tests {
         let location = PointQuery {
             attributes: vec!["color"],
             location: PointLocation::AllPoints,
-            global_from_query: None,
         };
         let octree_slice: &[Octree] = std::slice::from_ref(&octree);
         let mut parallel_iterator = ParallelIterator::new(

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -1,7 +1,7 @@
 use crate::data_provider::DataProvider;
 use crate::errors::*;
 use crate::iterator::{FilteredIterator, PointCloud, PointLocation, PointQuery};
-use crate::math::{Cuboid, Isometry3};
+use crate::math::Cuboid;
 use crate::proto;
 use crate::read_write::{Encoding, NodeIterator};
 use crate::{AttributeDataType, PointCloudMeta, CURRENT_VERSION};

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -174,11 +174,9 @@ impl PointCloud for S2Cells {
     fn nodes_in_location(&self, query: &PointQuery) -> Vec<Self::Id> {
         match &query.location {
             PointLocation::AllPoints => self.cells.keys().cloned().map(S2CellId).collect(),
-            PointLocation::Aabb(aabb) => self.cells_in_cuboid(aabb, &query.global_from_query),
-            PointLocation::Obb(obb) => self.cells_in_cuboid(obb, &query.global_from_query),
-            PointLocation::Frustum(frustum) => {
-                self.cells_in_cuboid(frustum, &query.global_from_query)
-            }
+            PointLocation::Aabb(aabb) => self.cells_in_cuboid(aabb),
+            PointLocation::Obb(obb) => self.cells_in_cuboid(obb),
+            PointLocation::Frustum(frustum) => self.cells_in_cuboid(frustum),
         }
     }
 
@@ -230,18 +228,11 @@ impl S2Cells {
     }
 
     /// Wrapper arround cells_in_convex_hull for Obbs
-    fn cells_in_cuboid<T>(
-        &self,
-        cuboid: &T,
-        global_from_query: &Option<Isometry3<f64>>,
-    ) -> Vec<S2CellId>
+    fn cells_in_cuboid<T>(&self, cuboid: &T) -> Vec<S2CellId>
     where
         T: Cuboid<f64>,
     {
-        self.cells_in_convex_hull(cuboid.corners().iter().map(|c| match global_from_query {
-            Some(g_from_q) => g_from_q * c,
-            None => *c,
-        }))
+        self.cells_in_convex_hull(cuboid.corners().iter().cloned())
     }
 
     /// Returns all cells that intersect the convex hull of the given points

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -494,11 +494,9 @@ pub fn xray_from_points(
     let _ = point_cloud_client.for_each_point_data(&point_query, |mut points_batch| {
         seen_any_points = true;
         if let Some(query_from_global) = query_from_global {
-            points_batch.position = points_batch
-                .position
-                .iter()
-                .map(|p| (query_from_global * &Point3::from_vec(*p)).to_vec())
-                .collect();
+            for p in &mut points_batch.position {
+                *p = (query_from_global * &Point3::from_vec(*p)).to_vec();
+            }
         }
         coloring_strategy.process_point_data(&points_batch, bbox, image_size);
         Ok(())

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -487,11 +487,11 @@ pub fn xray_from_points(
         }
         None => PointLocation::Aabb(*bbox),
     };
-    let point_location = PointQuery {
+    let point_query = PointQuery {
         attributes: coloring_strategy.attributes(),
         location,
     };
-    let _ = point_cloud_client.for_each_point_data(&point_location, |mut points_batch| {
+    let _ = point_cloud_client.for_each_point_data(&point_query, |mut points_batch| {
         seen_any_points = true;
         if let Some(query_from_global) = query_from_global {
             points_batch.position = points_batch

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -2,7 +2,7 @@
 
 use crate::proto;
 use crate::CURRENT_VERSION;
-use cgmath::{Decomposed, Point2, Point3, Quaternion, Vector2, Vector3};
+use cgmath::{Decomposed, EuclideanSpace, Point2, Point3, Quaternion, Vector2, Vector3};
 use clap::arg_enum;
 use collision::{Aabb, Aabb3};
 use fnv::{FnvHashMap, FnvHashSet};
@@ -10,7 +10,8 @@ use image::{self, GenericImage};
 use num::clamp;
 use point_cloud_client::PointCloudClient;
 use point_viewer::iterator::{PointLocation, PointQuery};
-use point_viewer::{color::Color, math::Isometry3, AttributeData, PointsBatch};
+use point_viewer::math::{Isometry3, Obb};
+use point_viewer::{color::Color, AttributeData, PointsBatch};
 use protobuf::Message;
 use quadtree::{ChildIndex, Node, NodeId, Rect};
 use scoped_pool::Pool;
@@ -471,7 +472,7 @@ pub struct Tile {
 
 pub fn xray_from_points(
     point_cloud_client: &PointCloudClient,
-    global_from_query: &Option<Isometry3<f64>>,
+    query_from_global: &Option<Isometry3<f64>>,
     bbox: &Aabb3<f64>,
     png_file: &Path,
     image_size: Vector2<u32>,
@@ -479,13 +480,26 @@ pub fn xray_from_points(
     tile_background_color: Color<u8>,
 ) -> bool {
     let mut seen_any_points = false;
+    let location = match query_from_global {
+        Some(query_from_global) => {
+            let global_from_query = query_from_global.inverse();
+            PointLocation::Obb(Obb::from(bbox).transformed(&global_from_query))
+        }
+        None => PointLocation::Aabb(*bbox),
+    };
     let point_location = PointQuery {
         attributes: coloring_strategy.attributes(),
-        location: PointLocation::Aabb(*bbox),
-        global_from_query: global_from_query.clone(),
+        location,
     };
-    let _ = point_cloud_client.for_each_point_data(&point_location, |points_batch| {
+    let _ = point_cloud_client.for_each_point_data(&point_location, |mut points_batch| {
         seen_any_points = true;
+        if let Some(query_from_global) = query_from_global {
+            points_batch.position = points_batch
+                .position
+                .iter()
+                .map(|p| (query_from_global * &Point3::from_vec(*p)).to_vec())
+                .collect();
+        }
         coloring_strategy.process_point_data(&points_batch, bbox, image_size);
         Ok(())
     });
@@ -558,7 +572,6 @@ pub fn build_xray_quadtree(
     let (all_nodes_tx, all_nodes_rx) = mpsc::channel();
     println!("Building level {}.", deepest_level);
 
-    let global_from_query = &query_from_global.as_ref().map(Isometry3::inverse);
     pool.scoped(|scope| {
         let mut open = vec![Node::root_with_bounding_rect(bounding_rect.clone())];
         while !open.is_empty() {
@@ -582,7 +595,7 @@ pub fn build_xray_quadtree(
                     );
                     if xray_from_points(
                         point_cloud_client,
-                        global_from_query,
+                        query_from_global,
                         &bbox,
                         &get_image_path(output_directory, node.id),
                         Vector2::new(tile.size_px, tile.size_px),


### PR DESCRIPTION
This simplifies code around culling and will allow for other culling types, which can not be transformed.