### PR TITLE
Disable threading for point cloud client inside X-ray creation.

### DIFF
--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -174,8 +174,11 @@ pub fn run<T: Extension>(data_provider_factory: DataProviderFactory) {
         .unwrap()
         .map(String::from)
         .collect::<Vec<_>>();
-    let point_cloud_client = PointCloudClient::new(&point_cloud_locations, data_provider_factory)
-        .expect("Could not create point cloud client.");
+    let mut point_cloud_client =
+        PointCloudClient::new(&point_cloud_locations, data_provider_factory)
+            .expect("Could not create point cloud client.");
+    // We do threading outside
+    point_cloud_client.num_threads = 1;
 
     let filter_intervals = args
         .values_of("filter_interval")


### PR DESCRIPTION
This just led to an unnecessary high amount of threads created. We now just do threading outside, so outer (X-ray) and inner (point cloud client) threads don't fight for computation time...