### PR TITLE
Introduce PointCloudClientBuilder.

### DIFF
--- a/point_cloud_client/src/bin/test.rs
+++ b/point_cloud_client/src/bin/test.rs
@@ -4,7 +4,6 @@
 use cgmath::Point3;
 use collision::Aabb3;
 use point_cloud_client::PointCloudClientBuilder;
-use point_viewer::data_provider::DataProviderFactory;
 use point_viewer::errors::{ErrorKind, Result};
 use point_viewer::iterator::{PointLocation, PointQuery};
 use point_viewer::PointsBatch;
@@ -64,12 +63,11 @@ struct CommandlineArguments {
 fn main() {
     let args = CommandlineArguments::from_args();
     let num_points = args.num_points;
-    let point_cloud_client =
-        PointCloudClientBuilder::new(&args.locations, DataProviderFactory::new())
-            .num_threads(args.num_threads)
-            .num_points_per_batch(args.batch_size)
-            .build()
-            .expect("Couldn't create point cloud client.");
+    let point_cloud_client = PointCloudClientBuilder::new(&args.locations)
+        .num_threads(args.num_threads)
+        .num_points_per_batch(args.batch_size)
+        .build()
+        .expect("Couldn't create point cloud client.");
 
     let point_location = PointQuery {
         attributes: vec!["color", "intensity"],

--- a/point_cloud_client/src/bin/test.rs
+++ b/point_cloud_client/src/bin/test.rs
@@ -3,7 +3,7 @@
 
 use cgmath::Point3;
 use collision::Aabb3;
-use point_cloud_client::PointCloudClient;
+use point_cloud_client::PointCloudClientBuilder;
 use point_viewer::data_provider::DataProviderFactory;
 use point_viewer::errors::{ErrorKind, Result};
 use point_viewer::iterator::{PointLocation, PointQuery};
@@ -64,10 +64,12 @@ struct CommandlineArguments {
 fn main() {
     let args = CommandlineArguments::from_args();
     let num_points = args.num_points;
-    let mut point_cloud_client = PointCloudClient::new(&args.locations, DataProviderFactory::new())
-        .expect("Couldn't create octree client.");
-    point_cloud_client.num_threads = args.num_threads;
-    point_cloud_client.num_points_per_batch = args.batch_size;
+    let point_cloud_client =
+        PointCloudClientBuilder::new(&args.locations, DataProviderFactory::new())
+            .num_threads(args.num_threads)
+            .num_points_per_batch(args.batch_size)
+            .build()
+            .expect("Couldn't create point cloud client.");
 
     let point_location = PointQuery {
         attributes: vec!["color", "intensity"],

--- a/point_cloud_client/src/lib.rs
+++ b/point_cloud_client/src/lib.rs
@@ -14,19 +14,88 @@ enum PointClouds {
 pub struct PointCloudClient {
     point_clouds: PointClouds,
     aabb: Aabb3<f64>,
-    pub num_points_per_batch: usize,
-    pub num_threads: usize,
-    pub buffer_size: usize,
+    num_points_per_batch: usize,
+    num_threads: usize,
+    buffer_size: usize,
 }
 
 impl PointCloudClient {
-    pub fn new(locations: &[String], data_provider_factory: DataProviderFactory) -> Result<Self> {
-        if locations.is_empty() {
+    pub fn bounding_box(&self) -> &Aabb3<f64> {
+        &self.aabb
+    }
+
+    pub fn for_each_point_data<F>(&self, point_query: &PointQuery, mut func: F) -> Result<()>
+    where
+        F: FnMut(PointsBatch) -> Result<()>,
+    {
+        match &self.point_clouds {
+            PointClouds::Octrees(octrees) => {
+                let mut parallel_iterator = ParallelIterator::new(
+                    octrees,
+                    point_query,
+                    self.num_points_per_batch,
+                    self.num_threads,
+                    self.buffer_size,
+                );
+                parallel_iterator.try_for_each_batch(&mut func)?;
+            }
+            PointClouds::S2Cells(s2_cells) => {
+                let mut parallel_iterator = ParallelIterator::new(
+                    s2_cells,
+                    point_query,
+                    self.num_points_per_batch,
+                    self.num_threads,
+                    self.buffer_size,
+                );
+                parallel_iterator.try_for_each_batch(&mut func)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct PointCloudClientBuilder<'a> {
+    locations: &'a [String],
+    data_provider_factory: DataProviderFactory,
+    num_points_per_batch: usize,
+    num_threads: usize,
+    buffer_size: usize,
+}
+
+impl<'a> PointCloudClientBuilder<'a> {
+    pub fn new(locations: &'a [String], data_provider_factory: DataProviderFactory) -> Self {
+        Self {
+            locations,
+            data_provider_factory,
+            num_points_per_batch: NUM_POINTS_PER_BATCH,
+            num_threads: num_cpus::get() - 1,
+            buffer_size: 4,
+        }
+    }
+
+    pub fn num_points_per_batch(mut self, num_points_per_batch: usize) -> Self {
+        self.num_points_per_batch = num_points_per_batch;
+        self
+    }
+
+    pub fn num_threads(mut self, num_threads: usize) -> Self {
+        self.num_threads = num_threads;
+        self
+    }
+
+    pub fn buffer_size(mut self, buffer_size: usize) -> Self {
+        self.buffer_size = buffer_size;
+        self
+    }
+
+    pub fn build(self) -> Result<PointCloudClient> {
+        if self.locations.is_empty() {
             return Err("No locations specified for point cloud client.".into());
         }
-        let data_providers = locations
+        let data_providers = self
+            .locations
             .iter()
-            .map(|location| data_provider_factory.generate_data_provider(location))
+            .map(|location| self.data_provider_factory.generate_data_provider(location))
             .collect::<Result<Vec<Box<dyn DataProvider>>>>()?;
         let mut aabb: Option<Aabb3<f64>> = None;
         let unite = |bbox: &Aabb3<f64>, with: &mut Option<Aabb3<f64>>| {
@@ -63,42 +132,9 @@ impl PointCloudClient {
         Ok(PointCloudClient {
             point_clouds,
             aabb: aabb.unwrap_or_else(Aabb3::zero),
-            num_points_per_batch: NUM_POINTS_PER_BATCH,
-            num_threads: num_cpus::get() - 1,
-            buffer_size: 4,
+            num_points_per_batch: self.num_points_per_batch,
+            num_threads: self.num_threads,
+            buffer_size: self.buffer_size,
         })
-    }
-
-    pub fn bounding_box(&self) -> &Aabb3<f64> {
-        &self.aabb
-    }
-
-    pub fn for_each_point_data<F>(&self, point_query: &PointQuery, mut func: F) -> Result<()>
-    where
-        F: FnMut(PointsBatch) -> Result<()>,
-    {
-        match &self.point_clouds {
-            PointClouds::Octrees(octrees) => {
-                let mut parallel_iterator = ParallelIterator::new(
-                    octrees,
-                    point_query,
-                    self.num_points_per_batch,
-                    self.num_threads,
-                    self.buffer_size,
-                );
-                parallel_iterator.try_for_each_batch(&mut func)?;
-            }
-            PointClouds::S2Cells(s2_cells) => {
-                let mut parallel_iterator = ParallelIterator::new(
-                    s2_cells,
-                    point_query,
-                    self.num_points_per_batch,
-                    self.num_threads,
-                    self.buffer_size,
-                );
-                parallel_iterator.try_for_each_batch(&mut func)?;
-            }
-        }
-        Ok(())
     }
 }

--- a/point_cloud_test/src/lib.rs
+++ b/point_cloud_test/src/lib.rs
@@ -1,7 +1,7 @@
 use point_cloud_client::{PointCloudClient, PointCloudClientBuilder};
 /// This module has functions to generate synthetic point clouds in a temp dir
 /// and provides queries on these synthetic point clouds.
-use point_viewer::data_provider::{DataProviderFactory, OnDiskDataProvider};
+use point_viewer::data_provider::OnDiskDataProvider;
 use point_viewer::octree::{build_octree, Octree};
 use point_viewer::read_write::{Encoding, NodeWriter, OpenMode, RawNodeWriter, S2Splitter};
 use point_viewer::s2_cells::S2Cells;
@@ -114,16 +114,14 @@ pub fn setup_pointcloud(args: &Arguments) -> (S2Cells, Octree, SyntheticData) {
 pub fn setup_s2_client(args: &Arguments) -> (PointCloudClient, SyntheticData) {
     let (s2_path_buf, _, data) = get_s2_and_octree_path(args);
     let s2_locations = &[s2_path_buf.to_str().unwrap().to_owned()];
-    let client = PointCloudClientBuilder::new(s2_locations, DataProviderFactory::new())
-        .build()
-        .unwrap();
+    let client = PointCloudClientBuilder::new(s2_locations).build().unwrap();
     (client, data)
 }
 
 pub fn setup_octree_client(args: &Arguments) -> (PointCloudClient, SyntheticData) {
     let (_, oct_path_buf, data) = get_s2_and_octree_path(args);
     let octree_locations = &[oct_path_buf.to_str().unwrap().to_owned()];
-    let client = PointCloudClientBuilder::new(octree_locations, DataProviderFactory::new())
+    let client = PointCloudClientBuilder::new(octree_locations)
         .build()
         .unwrap();
     (client, data)

--- a/point_cloud_test/src/lib.rs
+++ b/point_cloud_test/src/lib.rs
@@ -1,4 +1,4 @@
-use point_cloud_client::PointCloudClient;
+use point_cloud_client::{PointCloudClient, PointCloudClientBuilder};
 /// This module has functions to generate synthetic point clouds in a temp dir
 /// and provides queries on these synthetic point clouds.
 use point_viewer::data_provider::{DataProviderFactory, OnDiskDataProvider};
@@ -114,13 +114,17 @@ pub fn setup_pointcloud(args: &Arguments) -> (S2Cells, Octree, SyntheticData) {
 pub fn setup_s2_client(args: &Arguments) -> (PointCloudClient, SyntheticData) {
     let (s2_path_buf, _, data) = get_s2_and_octree_path(args);
     let s2_locations = &[s2_path_buf.to_str().unwrap().to_owned()];
-    let client = PointCloudClient::new(s2_locations, DataProviderFactory::new()).unwrap();
+    let client = PointCloudClientBuilder::new(s2_locations, DataProviderFactory::new())
+        .build()
+        .unwrap();
     (client, data)
 }
 
 pub fn setup_octree_client(args: &Arguments) -> (PointCloudClient, SyntheticData) {
     let (_, oct_path_buf, data) = get_s2_and_octree_path(args);
     let octree_locations = &[oct_path_buf.to_str().unwrap().to_owned()];
-    let client = PointCloudClient::new(octree_locations, DataProviderFactory::new()).unwrap();
+    let client = PointCloudClientBuilder::new(octree_locations, DataProviderFactory::new())
+        .build()
+        .unwrap();
     (client, data)
 }

--- a/point_viewer_grpc/src/bin/octree_benchmark.rs
+++ b/point_viewer_grpc/src/bin/octree_benchmark.rs
@@ -69,7 +69,7 @@ fn main() {
     let num_threads = usize::from_str(
         matches
             .value_of("num-threads")
-            .unwrap_or(&(num_cpus::get() - 1).to_string()),
+            .unwrap_or(&(std::cmp::max(1, num_cpus::get() - 1)).to_string()),
     )
     .expect("num-threads needs to be a number");
     let buffer_size = usize::from_str(matches.value_of("buffer-size").unwrap_or("4"))

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -303,7 +303,7 @@ impl OctreeService {
                     octree_slice,
                     &point_query,
                     num_points_per_batch,
-                    num_cpus::get() - 1,
+                    std::cmp::max(1, num_cpus::get() - 1),
                     buffer_size,
                 );
                 // TODO(catevita): missing error handling for the thread

--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -174,12 +174,12 @@ pub fn run<T: Extension>(data_provider_factory: DataProviderFactory) {
         .unwrap()
         .map(String::from)
         .collect::<Vec<_>>();
-    let point_cloud_client =
-        PointCloudClientBuilder::new(&point_cloud_locations, data_provider_factory)
-            // We do threading outside
-            .num_threads(1)
-            .build()
-            .expect("Could not create point cloud client.");
+    let point_cloud_client = PointCloudClientBuilder::new(&point_cloud_locations)
+        .data_provider_factory(data_provider_factory)
+        // We do threading outside
+        .num_threads(1)
+        .build()
+        .expect("Could not create point cloud client.");
 
     let filter_intervals = args
         .values_of("filter_interval")

--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -3,7 +3,7 @@ use crate::generation::{
     TileBackgroundColorArgument, XrayParameters,
 };
 use clap::value_t;
-use point_cloud_client::PointCloudClient;
+use point_cloud_client::PointCloudClientBuilder;
 use point_viewer::color::{TRANSPARENT, WHITE};
 use point_viewer::data_provider::DataProviderFactory;
 use point_viewer::math::{ClosedInterval, Isometry3};
@@ -174,11 +174,12 @@ pub fn run<T: Extension>(data_provider_factory: DataProviderFactory) {
         .unwrap()
         .map(String::from)
         .collect::<Vec<_>>();
-    let mut point_cloud_client =
-        PointCloudClient::new(&point_cloud_locations, data_provider_factory)
+    let point_cloud_client =
+        PointCloudClientBuilder::new(&point_cloud_locations, data_provider_factory)
+            // We do threading outside
+            .num_threads(1)
+            .build()
             .expect("Could not create point cloud client.");
-    // We do threading outside
-    point_cloud_client.num_threads = 1;
 
     let filter_intervals = args
         .values_of("filter_interval")


### PR DESCRIPTION
This is mainly to clean up interfaces and get rid of public members in `PointCloudClient`.