### PR TITLE
Factor out filtering code into a provided method

### DIFF
--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -159,8 +159,8 @@ pub trait PointCloud: Sync {
     fn bounding_box(&self) -> &Aabb3<f64>;
 
     /// Return the points matching the query in the selected node.
-    /// Why only a single node? Because the nodes are distributed to several `PointStream`s working
-    /// in parallel by the `ParallelIterator`.
+    /// Why only a single node? Because the nodes are distributed to several `PointStream` instances
+    /// working in parallel by the `ParallelIterator`.
     fn stream_points_for_query_in_node<F>(
         &self,
         query: &PointQuery,

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -321,27 +321,21 @@ impl PointCloud for Octree {
         self.meta.encoding_for_node(id)
     }
 
-    fn points_in_node<'a>(
-        &'a self,
-        query: &'a PointQuery,
-        node_id: NodeId,
+    fn points_in_node(
+        &self,
+        attributes: &[&str],
+        node_id: Self::Id,
         batch_size: usize,
-    ) -> Result<FilteredIterator<'a>> {
-        let culling = query.location.get_point_culling();
-        let filter_intervals = &query.filter_intervals;
+    ) -> Result<NodeIterator> {
         let node_iterator = NodeIterator::from_data_provider(
             &*self.data_provider,
-            &self.meta.attribute_data_types_for(&query.attributes)?,
+            &self.meta.attribute_data_types_for(&attributes)?,
             self.meta.encoding_for_node(node_id),
             &node_id,
             self.nodes[&node_id].num_points as usize,
             batch_size,
         )?;
-        Ok(FilteredIterator {
-            culling,
-            filter_intervals,
-            node_iterator,
-        })
+        Ok(node_iterator)
     }
 
     /// return the bounding box saved in meta

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -14,7 +14,7 @@
 use crate::data_provider::DataProvider;
 use crate::errors::*;
 use crate::geometry::Cube;
-use crate::iterator::{FilteredIterator, PointCloud, PointLocation, PointQuery};
+use crate::iterator::{PointCloud, PointLocation};
 use crate::proto;
 use crate::read_write::{Encoding, NodeIterator, PositionEncoding};
 use crate::{AttributeDataType, PointCloudMeta, CURRENT_VERSION};

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -172,28 +172,22 @@ impl PointCloud for S2Cells {
         Encoding::Plain
     }
 
-    fn points_in_node<'a>(
-        &'a self,
-        query: &'a PointQuery,
+    fn points_in_node(
+        &self,
+        attributes: &[&str],
         node_id: Self::Id,
         batch_size: usize,
-    ) -> Result<FilteredIterator<'a>> {
-        let culling = query.location.get_point_culling();
-        let filter_intervals = &query.filter_intervals;
+    ) -> Result<NodeIterator> {
         let num_points = self.meta.cells[&node_id].num_points as usize;
         let node_iterator = NodeIterator::from_data_provider(
             &*self.data_provider,
-            &self.meta.attribute_data_types_for(&query.attributes)?,
+            &self.meta.attribute_data_types_for(&attributes)?,
             self.encoding_for_node(node_id),
             &node_id,
             num_points,
             batch_size,
         )?;
-        Ok(FilteredIterator {
-            culling,
-            filter_intervals,
-            node_iterator,
-        })
+        Ok(node_iterator)
     }
 
     fn bounding_box(&self) -> &Aabb3<f64> {

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -1,6 +1,6 @@
 use crate::data_provider::DataProvider;
 use crate::errors::*;
-use crate::iterator::{FilteredIterator, PointCloud, PointLocation, PointQuery};
+use crate::iterator::{PointCloud, PointLocation};
 use crate::math::{Cuboid, S2Point};
 use crate::proto;
 use crate::read_write::{Encoding, NodeIterator};


### PR DESCRIPTION
The code for fetching filtered points batches in a node currently only differs in the part that gets us a NodeIterator. We can factor out the part that filters the points. This makes it easier to see where the two point cloud types actually differ, and reduces code duplication.