### PR TITLE
Generalize Cuboid trait to ConvexPolyhedron, generalize SAT intersection testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,6 +1993,7 @@ dependencies = [
 name = "point_viewer"
 version = "0.1.0"
 dependencies = [
+ "arrayvec",
  "byteorder",
  "cgmath 0.17.0",
  "collision",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+arrayvec = "0.5.1"
 byteorder = "1.3.4"
 cgmath = { version = "0.17.0", features = ["serde"] }
 collision = { version = "0.20.1", features = ["serde"] }

--- a/src/geometry/cube.rs
+++ b/src/geometry/cube.rs
@@ -1,6 +1,6 @@
 //! An axis-aligned cube.
 
-use crate::math::sat::{self, ConvexPolyhedron, Relation};
+use crate::math::sat::{self, ConvexPolyhedron, Intersector, Relation};
 use crate::math::PointCulling;
 use arrayvec::ArrayVec;
 use cgmath::{BaseFloat, Point3, Vector3};
@@ -34,16 +34,17 @@ where
         self.to_corners()
     }
 
-    fn compute_edges(&self) -> ArrayVec<[Vector3<S>; 6]> {
-        let mut edges = ArrayVec::new();
-        edges.push(Vector3::unit_x());
-        edges.push(Vector3::unit_y());
-        edges.push(Vector3::unit_z());
-        edges
-    }
-
-    fn compute_face_normals(&self) -> ArrayVec<[Vector3<S>; 6]> {
-        self.compute_edges()
+    fn intersector(&self) -> Intersector<S> {
+        let mut unit_axes = ArrayVec::new();
+        unit_axes.push(Vector3::unit_x());
+        unit_axes.push(Vector3::unit_y());
+        unit_axes.push(Vector3::unit_z());
+        let corners = self.compute_corners();
+        Intersector {
+            corners,
+            edges: unit_axes.clone(),
+            face_normals: unit_axes,
+        }
     }
 }
 

--- a/src/geometry/frustum.rs
+++ b/src/geometry/frustum.rs
@@ -113,7 +113,7 @@ where
         face_normals.push((edges[0].cross(edges[2])).normalize()); // Lower side
         face_normals.push((edges[0].cross(edges[3])).normalize()); // Upper side
         face_normals.push((edges[1].cross(edges[2])).normalize()); // Left side
-        face_normals.push((edges[1].cross(edges[2])).normalize()); // right side
+        face_normals.push((edges[1].cross(edges[4])).normalize()); // right side
 
         Intersector {
             corners,

--- a/src/geometry/frustum.rs
+++ b/src/geometry/frustum.rs
@@ -1,7 +1,11 @@
 //! An asymmetric frustum with an arbitrary 3D pose.
 
-use crate::math::{Cuboid, Isometry3, PointCulling};
-use cgmath::{BaseFloat, Decomposed, Matrix4, Perspective, Point3, Quaternion, Transform, Vector3};
+use crate::math::sat::{ConvexPolyhedron, Intersector};
+use crate::math::{Isometry3, PointCulling};
+use arrayvec::ArrayVec;
+use cgmath::{
+    BaseFloat, Decomposed, InnerSpace, Matrix4, Perspective, Point3, Quaternion, Transform, Vector3,
+};
 use collision::{Aabb3, Relation};
 use serde::{Deserialize, Serialize};
 
@@ -58,11 +62,11 @@ where
     }
 }
 
-impl<S> Cuboid<S> for Frustum<S>
+impl<S> ConvexPolyhedron<S> for Frustum<S>
 where
     S: BaseFloat,
 {
-    fn corners(&self) -> [Point3<S>; 8] {
+    fn compute_corners(&self) -> [Point3<S>; 8] {
         let corner_from = |x, y, z| self.query_from_clip.transform_point(Point3::new(x, y, z));
         [
             corner_from(-S::one(), -S::one(), -S::one()),
@@ -74,5 +78,47 @@ where
             corner_from(S::one(), S::one(), -S::one()),
             corner_from(S::one(), S::one(), S::one()),
         ]
+    }
+
+    fn compute_edges(&self) -> ArrayVec<[Vector3<S>; 6]> {
+        // To compute the edges, we need the points, so it's more efficient to implement
+        // intersector() directly and compute the points only once. We still provide this
+        // function, but it will not be used since intersection testing only needs
+        // intersector().
+        self.intersector().edges
+    }
+
+    fn compute_face_normals(&self) -> ArrayVec<[Vector3<S>; 6]> {
+        // To compute the face normals, we need the edges, so it's more efficient to
+        // implement intersector() directly and compute the points and edges only once.
+        // We still provide this function, but it will not be used since intersection
+        // testing only needs intersector().
+        self.intersector().face_normals
+    }
+
+    fn intersector(&self) -> Intersector<S> {
+        let corners = self.compute_corners();
+
+        let edges = ArrayVec::from([
+            (corners[4] - corners[0]).normalize(), // x
+            (corners[2] - corners[0]).normalize(), // y
+            (corners[1] - corners[0]).normalize(), // z lower left
+            (corners[3] - corners[2]).normalize(), // z upper left
+            (corners[5] - corners[4]).normalize(), // z lower right
+            (corners[7] - corners[6]).normalize(), // z upper right
+        ]);
+
+        let mut face_normals = ArrayVec::new();
+        face_normals.push((edges[0].cross(edges[1])).normalize()); // Front and back sides
+        face_normals.push((edges[0].cross(edges[2])).normalize()); // Lower side
+        face_normals.push((edges[0].cross(edges[3])).normalize()); // Upper side
+        face_normals.push((edges[1].cross(edges[2])).normalize()); // Left side
+        face_normals.push((edges[1].cross(edges[2])).normalize()); // right side
+
+        Intersector {
+            corners,
+            edges,
+            face_normals,
+        }
     }
 }

--- a/src/geometry/frustum.rs
+++ b/src/geometry/frustum.rs
@@ -97,7 +97,7 @@ where
         face_normals.push((edges[0].cross(edges[2])).normalize()); // Lower side
         face_normals.push((edges[0].cross(edges[3])).normalize()); // Upper side
         face_normals.push((edges[1].cross(edges[2])).normalize()); // Left side
-        face_normals.push((edges[1].cross(edges[4])).normalize()); // right side
+        face_normals.push((edges[1].cross(edges[4])).normalize()); // Right side
 
         Intersector {
             corners,

--- a/src/geometry/frustum.rs
+++ b/src/geometry/frustum.rs
@@ -80,22 +80,6 @@ where
         ]
     }
 
-    fn compute_edges(&self) -> ArrayVec<[Vector3<S>; 6]> {
-        // To compute the edges, we need the points, so it's more efficient to implement
-        // intersector() directly and compute the points only once. We still provide this
-        // function, but it will not be used since intersection testing only needs
-        // intersector().
-        self.intersector().edges
-    }
-
-    fn compute_face_normals(&self) -> ArrayVec<[Vector3<S>; 6]> {
-        // To compute the face normals, we need the edges, so it's more efficient to
-        // implement intersector() directly and compute the points and edges only once.
-        // We still provide this function, but it will not be used since intersection
-        // testing only needs intersector().
-        self.intersector().face_normals
-    }
-
     fn intersector(&self) -> Intersector<S> {
         let corners = self.compute_corners();
 

--- a/src/geometry/obb.rs
+++ b/src/geometry/obb.rs
@@ -1,18 +1,39 @@
 //! A bounding box with an arbitrary 3D pose.
 
-use crate::math::{intersects_aabb3, Cuboid, Isometry3, PointCulling};
+use crate::math::{CachedAxesIntersector, ConvexPolyhedron, Relation};
+use crate::math::{Isometry3, PointCulling};
+use arrayvec::ArrayVec;
 use cgmath::{BaseFloat, EuclideanSpace, InnerSpace, Point3, Quaternion, Vector3};
 use collision::{Aabb, Aabb3};
 use num_traits::identities::One;
+use num_traits::Bounded;
 use serde::{Deserialize, Serialize};
 
+/// An oriented bounding box.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Obb<S> {
     query_from_obb: Isometry3<S>,
     obb_from_query: Isometry3<S>,
     half_extent: Vector3<S>,
-    corners: [Point3<S>; 8],
-    pub separating_axes: Vec<Vector3<S>>,
+}
+
+/// Will be removed in the next PR.
+pub struct CachedAxesObb<S: BaseFloat> {
+    pub obb: Obb<S>,
+    pub separating_axes: CachedAxesIntersector<S>,
+}
+
+impl<S: BaseFloat + Bounded> CachedAxesObb<S> {
+    pub fn new(obb: Obb<S>) -> Self {
+        let unit_axes = [Vector3::unit_x(), Vector3::unit_y(), Vector3::unit_z()];
+        let separating_axes = obb
+            .intersector()
+            .cache_separating_axes(&unit_axes, &unit_axes);
+        Self {
+            obb,
+            separating_axes,
+        }
+    }
 }
 
 impl<S: BaseFloat> From<&Aabb3<S>> for Obb<S> {
@@ -34,95 +55,59 @@ impl<S: BaseFloat> Obb<S> {
     pub fn new(query_from_obb: Isometry3<S>, half_extent: Vector3<S>) -> Self {
         Obb {
             obb_from_query: query_from_obb.inverse(),
-            half_extent,
-            corners: Obb::precompute_corners(&query_from_obb, &half_extent),
-            separating_axes: Obb::precompute_separating_axes(&query_from_obb.rotation),
             query_from_obb,
+            half_extent,
         }
     }
 
     pub fn transformed(&self, global_from_query: &Isometry3<S>) -> Self {
         Self::new(global_from_query * &self.query_from_obb, self.half_extent)
     }
+}
 
-    fn precompute_corners(
-        query_from_obb: &Isometry3<S>,
-        half_extent: &Vector3<S>,
-    ) -> [Point3<S>; 8] {
-        let corner_from = |x, y, z| query_from_obb * &Point3::new(x, y, z);
+impl<S: BaseFloat> ConvexPolyhedron<S> for Obb<S> {
+    fn compute_corners(&self) -> [Point3<S>; 8] {
+        let corner_from = |x, y, z| &self.query_from_obb * &Point3::new(x, y, z);
         [
-            corner_from(-half_extent.x, -half_extent.y, -half_extent.z),
-            corner_from(half_extent.x, -half_extent.y, -half_extent.z),
-            corner_from(-half_extent.x, half_extent.y, -half_extent.z),
-            corner_from(half_extent.x, half_extent.y, -half_extent.z),
-            corner_from(-half_extent.x, -half_extent.y, half_extent.z),
-            corner_from(half_extent.x, -half_extent.y, half_extent.z),
-            corner_from(-half_extent.x, half_extent.y, half_extent.z),
-            corner_from(half_extent.x, half_extent.y, half_extent.z),
+            corner_from(
+                -self.half_extent.x,
+                -self.half_extent.y,
+                -self.half_extent.z,
+            ),
+            corner_from(self.half_extent.x, -self.half_extent.y, -self.half_extent.z),
+            corner_from(-self.half_extent.x, self.half_extent.y, -self.half_extent.z),
+            corner_from(self.half_extent.x, self.half_extent.y, -self.half_extent.z),
+            corner_from(-self.half_extent.x, -self.half_extent.y, self.half_extent.z),
+            corner_from(self.half_extent.x, -self.half_extent.y, self.half_extent.z),
+            corner_from(-self.half_extent.x, self.half_extent.y, self.half_extent.z),
+            corner_from(self.half_extent.x, self.half_extent.y, self.half_extent.z),
         ]
     }
+    fn compute_edges(&self) -> ArrayVec<[Vector3<S>; 6]> {
+        let mut edges = ArrayVec::new();
+        edges.push((self.query_from_obb.rotation * Vector3::unit_x()).normalize());
+        edges.push((self.query_from_obb.rotation * Vector3::unit_y()).normalize());
+        edges.push((self.query_from_obb.rotation * Vector3::unit_z()).normalize());
+        edges
+    }
 
-    fn precompute_separating_axes(query_from_obb: &Quaternion<S>) -> Vec<Vector3<S>> {
-        let unit_x = Vector3::unit_x();
-        let unit_y = Vector3::unit_y();
-        let unit_z = Vector3::unit_z();
-        let rot_x = query_from_obb * unit_x;
-        let rot_y = query_from_obb * unit_y;
-        let rot_z = query_from_obb * unit_z;
-        let mut separating_axes = vec![unit_x, unit_y, unit_z];
-        for axis in &[
-            rot_x,
-            rot_y,
-            rot_z,
-            unit_x.cross(rot_x).normalize(),
-            unit_x.cross(rot_y).normalize(),
-            unit_x.cross(rot_z).normalize(),
-            unit_y.cross(rot_x).normalize(),
-            unit_y.cross(rot_y).normalize(),
-            unit_y.cross(rot_z).normalize(),
-            unit_z.cross(rot_x).normalize(),
-            unit_z.cross(rot_y).normalize(),
-            unit_z.cross(rot_z).normalize(),
-        ] {
-            let is_finite_and_non_parallel = is_finite(&axis)
-                && separating_axes.iter().all(|elem| {
-                    (elem - axis).magnitude() > S::default_epsilon()
-                        && (elem + axis).magnitude() > S::default_epsilon()
-                });
-            if is_finite_and_non_parallel {
-                separating_axes.push(*axis);
-            }
-        }
-        separating_axes
+    fn compute_face_normals(&self) -> ArrayVec<[Vector3<S>; 6]> {
+        self.compute_edges()
     }
 }
 
-impl<S> PointCulling<S> for Obb<S>
+impl<S> PointCulling<S> for CachedAxesObb<S>
 where
-    S: 'static + BaseFloat + Sync + Send,
+    S: 'static + Bounded + BaseFloat + Sync + Send,
 {
     fn contains(&self, p: &Point3<S>) -> bool {
-        let Point3 { x, y, z } = &self.obb_from_query * p;
-        x.abs() <= self.half_extent.x
-            && y.abs() <= self.half_extent.y
-            && z.abs() <= self.half_extent.z
+        let Point3 { x, y, z } = &self.obb.obb_from_query * p;
+        x.abs() <= self.obb.half_extent.x
+            && y.abs() <= self.obb.half_extent.y
+            && z.abs() <= self.obb.half_extent.z
     }
+
     fn intersects_aabb3(&self, aabb: &Aabb3<S>) -> bool {
-        intersects_aabb3(&self.corners, &self.separating_axes, aabb)
+        self.separating_axes.intersect(&aabb.compute_corners()) != Relation::Out
     }
-}
-
-impl<S> Cuboid<S> for Obb<S>
-where
-    S: BaseFloat,
-{
-    fn corners(&self) -> [Point3<S>; 8] {
-        self.corners
-    }
-}
-
-// This guards against the separating axes being NaN, which may happen when the
-// orientation aligns with the unit axes.
-fn is_finite<S: BaseFloat>(vec: &Vector3<S>) -> bool {
-    vec.x.is_finite() && vec.y.is_finite() && vec.z.is_finite()
 }

--- a/src/geometry/obb.rs
+++ b/src/geometry/obb.rs
@@ -63,14 +63,6 @@ impl<S: BaseFloat> Obb<S> {
     pub fn transformed(&self, global_from_query: &Isometry3<S>) -> Self {
         Self::new(global_from_query * &self.query_from_obb, self.half_extent)
     }
-
-    fn compute_edges(&self) -> ArrayVec<[Vector3<S>; 6]> {
-        let mut edges = ArrayVec::new();
-        edges.push((self.query_from_obb.rotation * Vector3::unit_x()).normalize());
-        edges.push((self.query_from_obb.rotation * Vector3::unit_y()).normalize());
-        edges.push((self.query_from_obb.rotation * Vector3::unit_z()).normalize());
-        edges
-    }
 }
 
 impl<S: BaseFloat> ConvexPolyhedron<S> for Obb<S> {
@@ -94,7 +86,10 @@ impl<S: BaseFloat> ConvexPolyhedron<S> for Obb<S> {
 
     fn intersector(&self) -> Intersector<S> {
         let corners = self.compute_corners();
-        let edges = self.compute_edges();
+        let mut edges = ArrayVec::new();
+        edges.push((self.query_from_obb.rotation * Vector3::unit_x()).normalize());
+        edges.push((self.query_from_obb.rotation * Vector3::unit_y()).normalize());
+        edges.push((self.query_from_obb.rotation * Vector3::unit_z()).normalize());
         Intersector {
             corners,
             edges: edges.clone(),

--- a/src/geometry/obb.rs
+++ b/src/geometry/obb.rs
@@ -17,7 +17,7 @@ pub struct Obb<S> {
     half_extent: Vector3<S>,
 }
 
-/// Will be removed in the next PR.
+/// TODO(nnmm): Remove
 pub struct CachedAxesObb<S: BaseFloat> {
     pub obb: Obb<S>,
     pub separating_axes: CachedAxesIntersector<S>,

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -61,7 +61,7 @@ macro_rules! with_point_culling {
             PointLocation::AllPoints => $closure(crate::math::AllPoints {}),
             PointLocation::Aabb(aabb) => $closure(aabb.clone()),
             PointLocation::Frustum(frustum) => $closure(frustum.clone()),
-            PointLocation::Obb(obb) => $closure(obb.clone()),
+            PointLocation::Obb(obb) => $closure(CachedAxesObb::new(obb.clone())),
             PointLocation::S2Cells(cell_union) => $closure(cell_union.clone()),
         }
     };

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,5 +1,5 @@
 use crate::errors::*;
-use crate::geometry::{Frustum, Obb};
+use crate::geometry::{CachedAxesObb, Frustum, Obb};
 use crate::math::{AllPoints, ClosedInterval, PointCulling};
 use crate::read_write::{Encoding, NodeIterator};
 use crate::{match_1d_attr_data, AttributeData, PointsBatch};
@@ -33,7 +33,7 @@ impl PointLocation {
             PointLocation::AllPoints => Box::new(AllPoints {}),
             PointLocation::Aabb(aabb) => Box::new(*aabb),
             PointLocation::Frustum(frustum) => Box::new(frustum.clone()),
-            PointLocation::Obb(obb) => Box::new(obb.clone()),
+            PointLocation::Obb(obb) => Box::new(CachedAxesObb::new(obb.clone())),
             PointLocation::S2Cells(cell_union) => Box::new(cell_union.clone()),
         }
     }

--- a/src/math/sat.rs
+++ b/src/math/sat.rs
@@ -47,29 +47,20 @@ pub trait ConvexPolyhedron<S: BaseFloat> {
     /// Using arrays should be cheaper than allocating a vector.
     /// We could also parametrize this trait by type-level numbers like nalgebra.
     fn compute_corners(&self) -> [Point3<S>; 8];
-    /// Compute the minimum number of edges. There should be no parallel/antiparallel
-    /// edges in the result.
-    fn compute_edges(&self) -> ArrayVec<[Vector3<S>; 6]>;
-    /// Like edges, only unique (up to sign) face normals are needed.
-    fn compute_face_normals(&self) -> ArrayVec<[Vector3<S>; 6]>;
-    /// Basically, collects the corners, edges and face normals.
-    fn intersector(&self) -> Intersector<S> {
-        let corners = self.compute_corners();
-        let edges = self.compute_edges();
-        let face_normals = self.compute_face_normals();
-        Intersector {
-            corners,
-            edges,
-            face_normals,
-        }
-    }
+    /// An intersector contains corners, edges and face normals. Edges and face normals should be
+    /// unique to get the best performance (antiparallel vectors are the same for this purpose).
+    fn intersector(&self) -> Intersector<S>;
 }
 
 /// When you have one object that is intersection tested against many others,
 /// compute this once (with the [`intersector`](trait.ConvexPolyhedron.html#method.intersector) method) and reuse it.
 pub struct Intersector<S: BaseFloat> {
+    /// The corners of the polyhedron.
     pub corners: [Point3<S>; 8],
+    /// The unique edges of the polyhedron.
+    /// This is hardcoded to 6 for now because we don't need more. Increase as needed.
     pub edges: ArrayVec<[Vector3<S>; 6]>,
+    /// The unique face normals of the polyhedron.
     pub face_normals: ArrayVec<[Vector3<S>; 6]>,
 }
 

--- a/src/math/sat.rs
+++ b/src/math/sat.rs
@@ -1,36 +1,261 @@
 //! Intersection checking by means of the separating axis theorem (SAT).
+//!
+//! Often, you want to do multiple intersection tests of the same object against
+//! many other objects. To not recompute the same things – namely corners, edges and face normals –
+//! each time, the [`Intersector`](struct.Intersector.html) struct can be reused between intersection tests
+//! in these cases. If the edges and face normals do not change between objects, create a
+//! [`CachedAxesIntersector`](struct.CachedAxesIntersector.html) and reuse it between intersection tests.
+//!
+//! ```no_run
+//! use cgmath::Vector3;
+//! use point_viewer::math::sat::ConvexPolyhedron;
+//! use point_viewer::geometry::{Aabb3, Obb, Frustum};
+//! // Use your imagination here
+//! let many_obbs: Vec<Obb<f64>> = unimplemented!();
+//! let many_aabbs: Vec<Aabb3<f64>> = unimplemented!();
+//! let frustum: Frustum<f64> = unimplemented!();
+//! // For a generic intersection, you can reuse the intersector:
+//! let frustum_intersector = frustum.intersector();
+//! for obb in many_obbs {
+//!   let relation = frustum_intersector.intersect(&obb.intersector());
+//! }
+//! // For intersection with many Aabbs, which can per definition only differ in
+//! // their corners, not their edges and face normals (which are both the axis vecs),
+//! // you can reuse not only the intersector, but also the separating axes:
+//! let unit_vecs = [Vector3::unit_x(), Vector3::unit_y(), Vector3::unit_y()];
+//! let frustum_cached_intersector = frustum.intersector().cache_separating_axes(&unit_vecs, &unit_vecs);
+//! for aabb in many_aabbs {
+//!   let relation = frustum_cached_intersector.intersect(&aabb.compute_corners());
+//! }
+//! ```
 
-use cgmath::{BaseFloat, EuclideanSpace, Point3, Vector3};
-use collision::Aabb3;
-use num_traits::Float;
+use arrayvec::ArrayVec;
+use cgmath::{Array, BaseFloat, EuclideanSpace, InnerSpace, Point3, Vector3};
+pub use collision::Relation;
+use num_traits::Bounded;
 
-pub fn intersects_aabb3<S: BaseFloat>(
-    corners: &[Point3<S>],
-    separating_axes: &[Vector3<S>],
-    aabb: &Aabb3<S>,
-) -> bool {
-    // SAT algorithm
-    // https://gamedev.stackexchange.com/questions/44500/how-many-and-which-axes-to-use-for-3d-obb-collision-with-sat
-    for sep_axis in separating_axes.iter() {
-        // Project the cube and the box onto that axis
-        let mut cube_min_proj: S = Float::max_value();
-        let mut cube_max_proj: S = Float::min_value();
-        for corner in aabb.to_corners().iter() {
-            let corner_proj = corner.dot(*sep_axis);
-            cube_min_proj = cube_min_proj.min(corner_proj);
-            cube_max_proj = cube_max_proj.max(corner_proj);
-        }
-        // Project corners of the box onto that axis
-        let mut box_min_proj: S = Float::max_value();
-        let mut box_max_proj: S = Float::min_value();
-        for corner in corners.iter() {
-            let corner_proj = corner.dot(*sep_axis);
-            box_min_proj = box_min_proj.min(corner_proj);
-            box_max_proj = box_max_proj.max(corner_proj);
-        }
-        if box_min_proj > cube_max_proj || box_max_proj < cube_min_proj {
-            return false;
+/// A trait for convex polyhedra that can perform intersection tests against other convex polyhedra.
+///
+/// The possible separating axes between two convex polyhedra are:
+/// * The face normals of polyhedron A
+/// * The face normals of polyhedron B
+/// * The cross product between all edge combinations of A and B
+/// Together with the corners, these are the sufficient statistics for the SAT test.
+/// Hence, corners, edges and face normals must be provided by implementors of this trait.
+pub trait ConvexPolyhedron<S: BaseFloat> {
+    /// For now, this is hardcoded to 8 corners and up to 6 edges/face normals.
+    /// Using arrays should be cheaper than allocating a vector.
+    /// We could also parametrize this trait by type-level numbers like nalgebra.
+    fn compute_corners(&self) -> [Point3<S>; 8];
+    /// Compute the minimum number of edges. There should be no parallel/antiparallel
+    /// edges in the result.
+    fn compute_edges(&self) -> ArrayVec<[Vector3<S>; 6]>;
+    /// Like edges, only unique (up to sign) face normals are needed.
+    fn compute_face_normals(&self) -> ArrayVec<[Vector3<S>; 6]>;
+    /// Basically, collects the corners, edges and face normals.
+    fn intersector(&self) -> Intersector<S> {
+        let corners = self.compute_corners();
+        let edges = self.compute_edges();
+        let face_normals = self.compute_face_normals();
+        Intersector {
+            corners,
+            edges,
+            face_normals,
         }
     }
-    true
+}
+
+/// When you have one object that is intersection tested against many others,
+/// compute this once (with the [`intersector`](trait.ConvexPolyhedron.html#method.intersector) method) and reuse it.
+pub struct Intersector<S: BaseFloat> {
+    pub corners: [Point3<S>; 8],
+    pub edges: ArrayVec<[Vector3<S>; 6]>,
+    pub face_normals: ArrayVec<[Vector3<S>; 6]>,
+}
+
+impl<S: BaseFloat + Bounded> Intersector<S> {
+    /// An iterator over separating axes – if we're only going to use the separating axes once,
+    /// we don't want to require an allocation.
+    fn separating_axes_iter<'a>(
+        &'a self,
+        other_edges: &'a [Vector3<S>],
+        other_face_normals: &'a [Vector3<S>],
+    ) -> impl Iterator<Item = Vector3<S>> + 'a {
+        let self_face_normals = self.face_normals.iter();
+        let nested_iter = move |e1| other_edges.iter().map(move |e2| (e1, e2));
+        let edge_cross_products = self
+            .edges
+            .iter()
+            .flat_map(nested_iter)
+            .filter_map(|(e1, e2)| {
+                let cross = e1.cross(*e2).normalize();
+                if cross.is_finite() {
+                    Some(cross)
+                } else {
+                    None
+                }
+            });
+        self_face_normals
+            .chain(other_face_normals)
+            .cloned()
+            .chain(edge_cross_products)
+    }
+
+    /// If you know that the edges and normals of the other object do not change, precompute
+    /// the separating axes with this function. It's essentially partially applying
+    /// [`intersect`](#method.intersect), leaving only the corners to be supplied.
+    ///
+    /// It applies deduplication of separating axes to speed up queries made using those axes.
+    /// That deduplication is currently O(n^2).
+    pub fn cache_separating_axes(
+        self,
+        other_edges: &[Vector3<S>],
+        other_face_normals: &[Vector3<S>],
+    ) -> CachedAxesIntersector<S> {
+        let all_axes: Vec<_> = self
+            .separating_axes_iter(other_edges, other_face_normals)
+            .collect();
+        let mut dedup_axes = Vec::new();
+        for ax1 in all_axes {
+            let is_dupe = dedup_axes.iter().any(|ax2: &Vector3<S>| {
+                let d1 = (ax1 - ax2).magnitude2();
+                let d2 = (ax1 + ax2).magnitude2();
+                d1.min(d2) < S::default_epsilon()
+            });
+            if !is_dupe {
+                dedup_axes.push(ax1);
+            }
+        }
+        CachedAxesIntersector {
+            axes: dedup_axes,
+            corners: self.corners,
+        }
+    }
+
+    /// Perform an intersection test. The resulting Relation expresses how the other object is spatially
+    /// related to the self object – e.g. if `Relation::In` is returned, the other object is completely
+    /// inside the self object.
+    pub fn intersect(&self, other: &Self) -> Relation {
+        sat(
+            self.separating_axes_iter(&other.edges, &other.face_normals),
+            &self.corners,
+            &other.corners,
+        )
+    }
+}
+
+/// Stores pre-computed separating axes for intersection tests.
+pub struct CachedAxesIntersector<S: BaseFloat> {
+    pub axes: Vec<Vector3<S>>,
+    pub corners: [Point3<S>; 8],
+}
+
+impl<S: BaseFloat + Bounded> CachedAxesIntersector<S> {
+    /// Perform an intersection test using the cached axes and the specified corner points. The resulting
+    /// Relation expresses how the other object is spatially related to the self object – e.g. if
+    /// `Relation::In` is returned, the other object is completely inside the self object.
+    pub fn intersect(&self, corners: &[Point3<S>]) -> Relation {
+        sat(self.axes.iter().cloned(), &self.corners, corners)
+    }
+}
+
+/// See https://www.gamedev.net/forums/topic/694911-separating-axis-theorem-3d-polygons/ for more detail
+/// Return `Relation::In` if B is contained in A
+pub fn sat<S, I>(separating_axes: I, corners_a: &[Point3<S>], corners_b: &[Point3<S>]) -> Relation
+where
+    S: BaseFloat + Bounded,
+    I: IntoIterator<Item = Vector3<S>>,
+{
+    let mut rel = Relation::In;
+    for sep_axis in separating_axes {
+        // Project corners of A onto that axis
+        let mut a_min_proj: S = Bounded::max_value();
+        let mut a_max_proj: S = Bounded::min_value();
+        for corner in corners_a {
+            let corner_proj = corner.to_vec().dot(sep_axis);
+            a_min_proj = a_min_proj.min(corner_proj);
+            a_max_proj = a_max_proj.max(corner_proj);
+        }
+        // Project corners of B onto that axis
+        let mut b_min_proj: S = Bounded::max_value();
+        let mut b_max_proj: S = Bounded::min_value();
+        for corner in corners_b {
+            let corner_proj = corner.to_vec().dot(sep_axis);
+            b_min_proj = b_min_proj.min(corner_proj);
+            b_max_proj = b_max_proj.max(corner_proj);
+        }
+        if b_min_proj > a_max_proj || b_max_proj < a_min_proj {
+            return Relation::Out;
+        }
+        // If B is not inside A wrt that axis, the only choice is between Cross and Out.
+        if a_min_proj > b_min_proj || b_max_proj > a_max_proj {
+            rel = Relation::Cross;
+        }
+    }
+    rel
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrayvec::ArrayVec;
+    use cgmath::{Point3, Vector3};
+
+    #[test]
+    fn test_cube_with_cube() {
+        let unit_vectors: ArrayVec<_> =
+            ArrayVec::from([Vector3::unit_x(), Vector3::unit_y(), Vector3::unit_z()])
+                .into_iter()
+                .collect();
+        #[rustfmt::skip]
+        let cube_isec_1 = Intersector {
+            corners: [
+                Point3::new(-1.0, -1.0, -1.0),
+                Point3::new(-1.0, -1.0,  1.0),
+                Point3::new(-1.0,  1.0, -1.0),
+                Point3::new(-1.0,  1.0,  1.0),
+                Point3::new( 1.0, -1.0, -1.0),
+                Point3::new( 1.0, -1.0,  1.0),
+                Point3::new( 1.0,  1.0, -1.0),
+                Point3::new( 1.0,  1.0,  1.0),
+            ],
+            edges: unit_vectors.clone(),
+            face_normals: unit_vectors.clone(),
+        };
+        #[rustfmt::skip]
+        let cube_isec_2 = Intersector {
+            corners: [
+                Point3::new(-0.5, -0.5, -0.5),
+                Point3::new(-0.5, -0.5,  1.5),
+                Point3::new(-0.5,  1.5, -0.5),
+                Point3::new(-0.5,  1.5,  1.5),
+                Point3::new( 1.5, -0.5, -0.5),
+                Point3::new( 1.5, -0.5,  1.5),
+                Point3::new( 1.5,  1.5, -0.5),
+                Point3::new( 1.5,  1.5,  1.5),
+            ],
+            edges: unit_vectors.clone(),
+            face_normals: unit_vectors.clone(),
+        };
+        #[rustfmt::skip]
+        let cube_isec_3 = Intersector {
+            corners: [
+                Point3::new(-0.9, -0.9, -0.9),
+                Point3::new(-0.9, -0.9, -0.7),
+                Point3::new(-0.9, -0.7, -0.9),
+                Point3::new(-0.9, -0.7, -0.7),
+                Point3::new(-0.7, -0.9, -0.9),
+                Point3::new(-0.7, -0.9, -0.7),
+                Point3::new(-0.7, -0.7, -0.9),
+                Point3::new(-0.7, -0.7, -0.7),
+            ],
+            edges: unit_vectors.clone(),
+            face_normals: unit_vectors.clone(),
+        };
+
+        assert_eq!(cube_isec_1.intersect(&cube_isec_2), Relation::Cross);
+        assert_eq!(cube_isec_2.intersect(&cube_isec_3), Relation::Out);
+        assert_eq!(cube_isec_1.intersect(&cube_isec_3), Relation::In);
+        assert_eq!(cube_isec_3.intersect(&cube_isec_1), Relation::Cross);
+    }
 }

--- a/src/math/sat.rs
+++ b/src/math/sat.rs
@@ -160,21 +160,10 @@ where
     let mut rel = Relation::In;
     for sep_axis in separating_axes {
         // Project corners of A onto that axis
-        let mut a_min_proj: S = Bounded::max_value();
-        let mut a_max_proj: S = Bounded::min_value();
-        for corner in corners_a {
-            let corner_proj = corner.to_vec().dot(sep_axis);
-            a_min_proj = a_min_proj.min(corner_proj);
-            a_max_proj = a_max_proj.max(corner_proj);
-        }
+        let (a_min_proj, a_max_proj) = project_on_axis(corners_a, sep_axis);
         // Project corners of B onto that axis
-        let mut b_min_proj: S = Bounded::max_value();
-        let mut b_max_proj: S = Bounded::min_value();
-        for corner in corners_b {
-            let corner_proj = corner.to_vec().dot(sep_axis);
-            b_min_proj = b_min_proj.min(corner_proj);
-            b_max_proj = b_max_proj.max(corner_proj);
-        }
+        let (b_min_proj, b_max_proj) = project_on_axis(corners_b, sep_axis);
+
         if b_min_proj > a_max_proj || b_max_proj < a_min_proj {
             return Relation::Out;
         }
@@ -184,6 +173,20 @@ where
         }
     }
     rel
+}
+
+fn project_on_axis<S>(corners: &[Point3<S>], sep_axis: Vector3<S>) -> (S, S)
+where
+    S: BaseFloat + Bounded,
+{
+    let mut min_proj: S = Bounded::max_value();
+    let mut max_proj: S = Bounded::min_value();
+    for corner in corners {
+        let corner_proj = corner.to_vec().dot(sep_axis);
+        min_proj = min_proj.min(corner_proj);
+        max_proj = max_proj.max(corner_proj);
+    }
+    (min_proj, max_proj)
 }
 
 #[cfg(test)]

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -1,7 +1,8 @@
 use crate::data_provider::DataProvider;
 use crate::errors::*;
 use crate::iterator::{PointCloud, PointLocation};
-use crate::math::{Cuboid, S2Point};
+use crate::math::sat::ConvexPolyhedron;
+use crate::math::S2Point;
 use crate::proto;
 use crate::read_write::{Encoding, NodeIterator};
 use crate::{AttributeDataType, PointCloudMeta, CURRENT_VERSION};
@@ -216,11 +217,11 @@ impl S2Cells {
     }
 
     /// Wrapper arround cells_in_convex_hull for Obbs
-    fn cells_in_cuboid<T>(&self, cuboid: &T) -> Vec<CellID>
+    fn cells_in_cuboid<T>(&self, poly: &T) -> Vec<CellID>
     where
-        T: Cuboid<f64>,
+        T: ConvexPolyhedron<f64>,
     {
-        self.cells_in_convex_hull(cuboid.corners().iter().cloned())
+        self.cells_in_convex_hull(poly.compute_corners().iter().cloned())
     }
 
     /// Returns all cells that intersect the convex hull of the given points


### PR DESCRIPTION
* Define a `ConvexPolyhedron` trait that provides everything we need to do intersection tests with other convex polyhedra.
* AABBs, OBBs and frustums are all convex polyhedra and so they are instances of that trait.
* We are especially interested in intersection tests with AABBs, since that's how we determine octree nodes for a query. Via SAT intersection testing, we can deal with the removal of `collision::Frustum` in https://github.com/googlecartographer/point_cloud_viewer/pull/415 because there is no equivalent in nalgebra, and as a nice side effect have one less way of how we do intersection testing.
  * Currently, `Frustum`'s `intersect_aabb3()` method still uses `collision::Frustum`, but will be switched to SAT in https://github.com/googlecartographer/point_cloud_viewer/pull/415
  * OBB intersection testing with AABBs was already implemented by SAT, but we separate out the precomputation result from the core struct
* The SAT intersection test is now capable of not only determining whether two objects intersect, but also whether the second is completely contained within the first. That is useful for e.g. skipping intersection tests for children of octree nodes that are completely within the query geometry.
* Better documentation for SAT intersection testing module.