### PR TITLE
Use criterion for benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,12 +461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
-name = "bencher"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
-
-[[package]]
 name = "bigdecimal"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +527,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
+
+[[package]]
 name = "bytemuck"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 dependencies = [
  "ppv-lite86",
+]
+
+[[package]]
+name = "cast"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -713,6 +734,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc755679c12bda8e5523a71e4d654b6bf2e14bd838dfc48cde6559a05caf7d1"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools 0.8.2",
+ "lazy_static",
+ "num-traits 0.2.11",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01e15e0ea58e8234f96146b1f91fa9d0e4dd7a38da93ff7a75d42c0b9d3a545"
+dependencies = [
+ "cast",
+ "itertools 0.8.2",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +835,28 @@ dependencies = [
  "autocfg 1.0.0",
  "cfg-if",
  "lazy_static",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1357,6 +1435,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "json"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,6 +1861,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
+
+[[package]]
 name = "ordered-float"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,6 +2017,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
+name = "plotters"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3bb8da247d27ae212529352020f3e5ee16e83c0c258061d27b08ab92675eeb"
+dependencies = [
+ "js-sys",
+ "num-traits 0.2.11",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "plugin"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,9 +2067,9 @@ dependencies = [
 name = "point_cloud_test_lib"
 version = "0.1.0"
 dependencies = [
- "bencher",
  "cgmath 0.17.0",
  "collision",
+ "criterion",
  "lazy_static",
  "num-integer",
  "point_cloud_client",
@@ -2452,6 +2557,15 @@ dependencies = [
  "memchr",
  "regex-syntax",
  "thread_local",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -2992,6 +3106,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3c6667d3e65eb1bc3aed6fd14011c6cbc3a0665218ab7f5daf040b9ec371a"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3231,6 +3355,70 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3557c397ab5a8e347d434782bcd31fc1483d927a6826804cec05cc792ee2519d"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0da9c9a19850d3af6df1cb9574970b566d617ecfaf36eb0b706b6f3ef9bd2f8"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log 0.4.8",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f6fde1d36e75a714b5fe0cffbb78978f222ea6baebb726af13c78869fdb4205"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25bda4168030a6412ea8a047e27238cadf56f0e53516e1e83fec0a8b7c786f6d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc9f36ad51f25b0219a3d4d13b90eb44cd075dff8b6280cca015775d7acaddd8"
+
+[[package]]
+name = "web-sys"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721c6263e2c66fd44501cc5efbfa2b7dfa775d13e4ea38c46299646ed1f9c70a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "widestring"

--- a/point_cloud_test/Cargo.toml
+++ b/point_cloud_test/Cargo.toml
@@ -24,7 +24,6 @@ authors = [
 edition = "2018"
 
 [dependencies]
-bencher = "0.1.5"
 cgmath = "0.17.0"
 collision = "0.20.1"
 lazy_static = "1.4.0"
@@ -36,6 +35,9 @@ rand = "0.7.3"
 rayon = "1.3.0"
 s2 = { version = "0.0.10", features = ["serde"] }
 tempdir = "0.3.7"
+
+[dev-dependencies]
+criterion = "0.3.1"
 
 [[bench]]
 name = "main"

--- a/point_cloud_test/benches/main.rs
+++ b/point_cloud_test/benches/main.rs
@@ -1,5 +1,4 @@
-// TODO(feuerste): Use #![feature(test)] instead of bencher once it is stable.
-use bencher::{benchmark_group, benchmark_main, black_box, Bencher};
+use criterion::{criterion_group, criterion_main, black_box, Criterion};
 use point_cloud_client::PointCloudClient;
 use point_cloud_test_lib::{
     get_abb_query, get_cell_union_query, get_frustum_query, get_obb_query, make_octree,
@@ -8,65 +7,65 @@ use point_cloud_test_lib::{
 use point_viewer::iterator::{PointLocation, PointQuery};
 use tempdir::TempDir;
 
-fn bench_octree_building_multithreaded(b: &mut Bencher) {
+fn bench_octree_building_multithreaded(c: &mut Criterion) {
     let mut args = Arguments::default();
     args.num_points = 100_000;
-    b.iter(|| {
+    c.bench_function("bench_octree_building_multithreaded", |b| b.iter(|| {
         let temp_dir = TempDir::new("octree").unwrap();
         make_octree(&args, temp_dir.path());
-    });
+    }));
 }
 
-fn bench_s2_building_singlethreaded(b: &mut Bencher) {
+fn bench_s2_building_singlethreaded(c: &mut Criterion) {
     let mut args = Arguments::default();
     args.num_points = 100_000;
-    b.iter(|| {
+    c.bench_function("bench_s2_building_singlethreaded", |b| b.iter(|| {
         let temp_dir = TempDir::new("s2").unwrap();
         make_s2_cells(&args, temp_dir.path());
-    });
+    }));
 }
 
-fn all_query_octree(b: &mut Bencher) {
-    run_bench(setup_octree_client, |_| PointLocation::AllPoints, b)
+fn all_query_octree(b: &mut Criterion) {
+    run_bench("all_query_octree", setup_octree_client, |_| PointLocation::AllPoints, b)
 }
 
-fn all_query_s2(b: &mut Bencher) {
-    run_bench(setup_s2_client, |_| PointLocation::AllPoints, b)
+fn all_query_s2(b: &mut Criterion) {
+    run_bench("all_query_s2", setup_s2_client, |_| PointLocation::AllPoints, b)
 }
 
-fn box_query_octree(b: &mut Bencher) {
-    run_bench(setup_octree_client, get_abb_query, b)
+fn box_query_octree(b: &mut Criterion) {
+    run_bench("box_query_octree", setup_octree_client, get_abb_query, b)
 }
 
-fn box_query_s2(b: &mut Bencher) {
-    run_bench(setup_s2_client, get_abb_query, b)
+fn box_query_s2(b: &mut Criterion) {
+    run_bench("box_query_s2", setup_s2_client, get_abb_query, b)
 }
 
-fn frustum_query_octree(b: &mut Bencher) {
-    run_bench(setup_octree_client, get_frustum_query, b)
+fn frustum_query_octree(b: &mut Criterion) {
+    run_bench("frustum_query_octree", setup_octree_client, get_frustum_query, b)
 }
 
-fn frustum_query_s2(b: &mut Bencher) {
-    run_bench(setup_s2_client, get_frustum_query, b)
+fn frustum_query_s2(b: &mut Criterion) {
+    run_bench("frustum_query_s2", setup_s2_client, get_frustum_query, b)
 }
 
-fn obb_query_octree(b: &mut Bencher) {
-    run_bench(setup_octree_client, get_obb_query, b)
+fn obb_query_octree(b: &mut Criterion) {
+    run_bench("obb_query_octree", setup_octree_client, get_obb_query, b)
 }
 
-fn obb_query_s2(b: &mut Bencher) {
-    run_bench(setup_s2_client, get_obb_query, b)
+fn obb_query_s2(b: &mut Criterion) {
+    run_bench("obb_query_s2", setup_s2_client, get_obb_query, b)
 }
 
-fn cell_union_query_octree(b: &mut Bencher) {
-    run_bench(setup_octree_client, get_cell_union_query, b)
+fn cell_union_query_octree(b: &mut Criterion) {
+    run_bench("cell_union_query_octree", setup_octree_client, get_cell_union_query, b)
 }
 
-fn cell_union_query_s2(b: &mut Bencher) {
-    run_bench(setup_s2_client, get_cell_union_query, b)
+fn cell_union_query_s2(b: &mut Criterion) {
+    run_bench("cell_union_query_s2", setup_s2_client, get_cell_union_query, b)
 }
 
-benchmark_group!(
+criterion_group!(
     benches,
     bench_octree_building_multithreaded,
     bench_s2_building_singlethreaded,
@@ -81,11 +80,11 @@ benchmark_group!(
     cell_union_query_octree,
     cell_union_query_s2,
 );
-benchmark_main!(benches);
+criterion_main!(benches);
 
 type SetupClientFn = fn(&Arguments) -> (PointCloudClient, SyntheticData);
 
-fn run_bench<F>(gen_client: SetupClientFn, gen_location: F, b: &mut Bencher)
+fn run_bench<F>(name: &'static str, gen_client: SetupClientFn, gen_location: F, c: &mut Criterion)
 where
     F: FnOnce(SyntheticData) -> PointLocation,
 {
@@ -96,11 +95,11 @@ where
         location: gen_location(data),
         ..Default::default()
     };
-    b.iter(|| {
+    c.bench_function(name, |b| b.iter(|| {
         let res = client.for_each_point_data(&query, |batch| {
             black_box(batch);
             Ok(())
         });
         assert!(res.is_ok());
-    });
+    }));
 }

--- a/point_cloud_test/benches/main.rs
+++ b/point_cloud_test/benches/main.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, black_box, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use point_cloud_client::PointCloudClient;
 use point_cloud_test_lib::{
     get_abb_query, get_cell_union_query, get_frustum_query, get_obb_query, make_octree,
@@ -10,27 +10,41 @@ use tempdir::TempDir;
 fn bench_octree_building_multithreaded(c: &mut Criterion) {
     let mut args = Arguments::default();
     args.num_points = 100_000;
-    c.bench_function("bench_octree_building_multithreaded", |b| b.iter(|| {
-        let temp_dir = TempDir::new("octree").unwrap();
-        make_octree(&args, temp_dir.path());
-    }));
+    c.bench_function("bench_octree_building_multithreaded", |b| {
+        b.iter(|| {
+            let temp_dir = TempDir::new("octree").unwrap();
+            make_octree(&args, temp_dir.path());
+        })
+    });
 }
 
 fn bench_s2_building_singlethreaded(c: &mut Criterion) {
     let mut args = Arguments::default();
     args.num_points = 100_000;
-    c.bench_function("bench_s2_building_singlethreaded", |b| b.iter(|| {
-        let temp_dir = TempDir::new("s2").unwrap();
-        make_s2_cells(&args, temp_dir.path());
-    }));
+    c.bench_function("bench_s2_building_singlethreaded", |b| {
+        b.iter(|| {
+            let temp_dir = TempDir::new("s2").unwrap();
+            make_s2_cells(&args, temp_dir.path());
+        })
+    });
 }
 
 fn all_query_octree(b: &mut Criterion) {
-    run_bench("all_query_octree", setup_octree_client, |_| PointLocation::AllPoints, b)
+    run_bench(
+        "all_query_octree",
+        setup_octree_client,
+        |_| PointLocation::AllPoints,
+        b,
+    )
 }
 
 fn all_query_s2(b: &mut Criterion) {
-    run_bench("all_query_s2", setup_s2_client, |_| PointLocation::AllPoints, b)
+    run_bench(
+        "all_query_s2",
+        setup_s2_client,
+        |_| PointLocation::AllPoints,
+        b,
+    )
 }
 
 fn box_query_octree(b: &mut Criterion) {
@@ -42,7 +56,12 @@ fn box_query_s2(b: &mut Criterion) {
 }
 
 fn frustum_query_octree(b: &mut Criterion) {
-    run_bench("frustum_query_octree", setup_octree_client, get_frustum_query, b)
+    run_bench(
+        "frustum_query_octree",
+        setup_octree_client,
+        get_frustum_query,
+        b,
+    )
 }
 
 fn frustum_query_s2(b: &mut Criterion) {
@@ -58,11 +77,21 @@ fn obb_query_s2(b: &mut Criterion) {
 }
 
 fn cell_union_query_octree(b: &mut Criterion) {
-    run_bench("cell_union_query_octree", setup_octree_client, get_cell_union_query, b)
+    run_bench(
+        "cell_union_query_octree",
+        setup_octree_client,
+        get_cell_union_query,
+        b,
+    )
 }
 
 fn cell_union_query_s2(b: &mut Criterion) {
-    run_bench("cell_union_query_s2", setup_s2_client, get_cell_union_query, b)
+    run_bench(
+        "cell_union_query_s2",
+        setup_s2_client,
+        get_cell_union_query,
+        b,
+    )
 }
 
 criterion_group!(
@@ -95,11 +124,13 @@ where
         location: gen_location(data),
         ..Default::default()
     };
-    c.bench_function(name, |b| b.iter(|| {
-        let res = client.for_each_point_data(&query, |batch| {
-            black_box(batch);
-            Ok(())
-        });
-        assert!(res.is_ok());
-    }));
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let res = client.for_each_point_data(&query, |batch| {
+                black_box(batch);
+                Ok(())
+            });
+            assert!(res.is_ok());
+        })
+    });
 }


### PR DESCRIPTION
With bencher, it was hard to get meaningful results:
* I couldn't find a way to increase the number of times a function is iterated, to get narrower error bars
* But that wouldn't help anyway because bencher reports the difference between the min and max as the error bar, so the error bar would only grow.

Criterion can be used like bencher (`cargo bench`) but has much nicer reporting. Sample output:

> Benchmarking bench_s2_building_singlethreaded: Warming up for 3.0000 s
> Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 828.6s or reduce sample count to 10.
> bench_s2_building_singlethreaded
>                         time:   [148.67 ms 149.33 ms 150.27 ms]
>                         change: [-6.5982% -3.3366% +0.3522%] (p = 0.06 > 0.05)
>                         No change in performance detected.
> Found 16 outliers among 100 measurements (16.00%)
>   14 (14.00%) high mild
>   2 (2.00%) high severe

As you can see, if you've run it before, it will compare the durations. It also does warmup runs, which helps decrease variance from disk caches.