### PR TITLE
Remove OctreeMeta's Default instance

### DIFF
--- a/src/octree/generation.rs
+++ b/src/octree/generation.rs
@@ -60,7 +60,7 @@ impl RawNodeWriter {
     }
 }
 
-// Return a list a leaf nodes and a list of nodes to be splitted further.
+// Return a list of leaf nodes and a list of nodes to be split further.
 fn split<P>(
     octree_data_provider: &OnDiskDataProvider,
     octree_meta: &octree::OctreeMeta,
@@ -302,11 +302,16 @@ pub fn build_octree(
 ) {
     attempt_increasing_rlimit_to_max();
 
-    // TODO(ksavinash9): This function should return a Result.
+    let attribute_data_types = vec![
+                ("color".to_string(), AttributeDataType::U8Vec3),
+                ("intensity".to_string(), AttributeDataType::F32),
+            ]
+            .into_iter()
+            .collect();
     let octree_meta = &octree::OctreeMeta {
         bounding_box,
         resolution,
-        ..Default::default()
+        attribute_data_types,
     };
     let attribute_data_types = &octree_meta.attribute_data_types_for(attributes).unwrap();
     let octree_data_provider = OnDiskDataProvider {

--- a/src/octree/generation.rs
+++ b/src/octree/generation.rs
@@ -302,17 +302,10 @@ pub fn build_octree(
 ) {
     attempt_increasing_rlimit_to_max();
 
-    let attribute_data_types = vec![
-                ("color".to_string(), AttributeDataType::U8Vec3),
-                ("intensity".to_string(), AttributeDataType::F32),
-            ]
-            .into_iter()
-            .collect();
-    let octree_meta = &octree::OctreeMeta {
-        bounding_box,
+    let octree_meta = &octree::OctreeMeta::new_with_standard_attributes(
         resolution,
-        attribute_data_types,
-    };
+        bounding_box,
+        );
     let attribute_data_types = &octree_meta.attribute_data_types_for(attributes).unwrap();
     let octree_data_provider = OnDiskDataProvider {
         directory: output_directory.as_ref().to_path_buf(),

--- a/src/octree/generation.rs
+++ b/src/octree/generation.rs
@@ -302,10 +302,7 @@ pub fn build_octree(
 ) {
     attempt_increasing_rlimit_to_max();
 
-    let octree_meta = &octree::OctreeMeta::new_with_standard_attributes(
-        resolution,
-        bounding_box,
-        );
+    let octree_meta = &octree::OctreeMeta::new_with_standard_attributes(resolution, bounding_box);
     let attribute_data_types = &octree_meta.attribute_data_types_for(attributes).unwrap();
     let octree_data_provider = OnDiskDataProvider {
         directory: output_directory.as_ref().to_path_buf(),

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -55,8 +55,8 @@ impl OctreeMeta {
     /// An octree currently does not store its data types, instead, color and
     /// intensity are implied. We already do have attributes as part of the
     /// meta data structure, but not its serialized form. So the data structure
-    /// is initialized with color and intensity hardcoded until it is in the
-    /// meta proto.
+    /// is initialized with color and intensity hardcoded until attributes are
+    /// in the meta proto.
     pub fn new_with_standard_attributes(resolution: f64, bounding_box: Aabb3<f64>) -> Self {
         let attribute_data_types = vec![
                         ("color".to_string(), AttributeDataType::U8Vec3),

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -59,11 +59,11 @@ impl OctreeMeta {
     /// in the meta proto.
     pub fn new_with_standard_attributes(resolution: f64, bounding_box: Aabb3<f64>) -> Self {
         let attribute_data_types = vec![
-                        ("color".to_string(), AttributeDataType::U8Vec3),
-                        ("intensity".to_string(), AttributeDataType::F32),
-                    ]
-                    .into_iter()
-                    .collect();
+            ("color".to_string(), AttributeDataType::U8Vec3),
+            ("intensity".to_string(), AttributeDataType::F32),
+        ]
+        .into_iter()
+        .collect();
         Self {
             resolution,
             bounding_box,
@@ -166,7 +166,8 @@ impl Octree {
                     bounding_box,
                     OctreeMeta::new_with_standard_attributes(
                         meta_proto.deprecated_resolution,
-                        bounding_box),
+                        bounding_box,
+                    ),
                     meta_proto.get_deprecated_nodes(),
                 )
             }
@@ -182,9 +183,7 @@ impl Octree {
                 });
                 (
                     bounding_box,
-                    OctreeMeta::new_with_standard_attributes(
-                        octree_meta.resolution,
-                        bounding_box),
+                    OctreeMeta::new_with_standard_attributes(octree_meta.resolution, bounding_box),
                     octree_meta.get_nodes(),
                 )
             }


### PR DESCRIPTION
This is to make https://github.com/googlecartographer/point_cloud_viewer/pull/415 smaller.

This makes the two dangerous/unexpected parts more explicit and doesn't allow them to hide in `..Default::default()`, namely:
* You shouldn't use a zero AABB as the bounding box for generation, but the Default instance gave you such an AABB.
* The two magic attributes "color" and "intensity".

The attribute data types are duplicated in two places now, but that's necessary for moving towards a state where octrees can have more attributes: The occurence in `build_octree()` will be removed, while the one in `from_data_provider()` will stay.

In the end, it's a matter of taste.