### PR TITLE
Expose quadtree level generation [AVMAPPING-8129]

### DIFF
--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -632,7 +632,7 @@ pub fn build_xray_quadtree(
         all_nodes.insert(*node);
     }
     for current_level in (0..deepest_level).rev() {
-        previous_level_nodes = generate_level(
+        previous_level_nodes = build_level(
             output_directory,
             tile,
             current_level,
@@ -685,7 +685,7 @@ enum ExistingStrategy {
     Panic,
 }
 
-fn generate_level(
+fn build_level(
     output_directory: &Path,
     tile: &Tile,
     current_level: u8,
@@ -702,14 +702,14 @@ fn generate_level(
         &format!("Building level {}", current_level),
     );
     nodes_to_create.par_iter().for_each(|node| {
-        generate_node(output_directory, *node, tile, parameters, existing_strategy);
+        build_node(output_directory, *node, tile, parameters, existing_strategy);
         progress_bar.lock().unwrap().inc();
     });
     progress_bar.lock().unwrap().finish_println("");
     nodes_to_create
 }
 
-fn generate_node(
+fn build_node(
     output_directory: &Path,
     node_id: NodeId,
     tile: &Tile,
@@ -733,7 +733,6 @@ fn generate_node(
     }
 
     let mut children = [None, None, None, None];
-
     // We a right handed coordinate system with the x-axis of world and images
     // aligning. This means that the y-axis aligns too, but the origin of the image
     // space must be at the bottom left. Since images have their origin at the top
@@ -757,7 +756,7 @@ fn generate_node(
         image
             .as_rgba8()
             .unwrap()
-            .save(&get_image_path(output_directory, node_id))
+            .save(&image_path)
             .unwrap();
     }
 }

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -679,10 +679,10 @@ fn build_level(
     output_directory: &Path,
     tile: &Tile,
     current_level: u8,
-    previous_level_nods: &FnvHashSet<NodeId>,
+    previous_level_nodes: &FnvHashSet<NodeId>,
     parameters: &XrayParameters,
 ) -> FnvHashSet<NodeId> {
-    let current_level_nodes: FnvHashSet<NodeId> = previous_level_nods
+    let current_level_nodes: FnvHashSet<NodeId> = previous_level_nodes
         .iter()
         .filter_map(|node| node.parent_id())
         .collect();

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -630,7 +630,15 @@ pub fn build_xray_quadtree(
     });
     progress_bar.lock().unwrap().finish_println("");
 
-    generate_levels(output_directory, tile, deepest_level, &created_leaf_node_ids, all_nodes_tx, parameters, ExistingStrategy::Panic);
+    generate_levels(
+        output_directory,
+        tile,
+        deepest_level,
+        &created_leaf_node_ids,
+        all_nodes_tx,
+        parameters,
+        ExistingStrategy::Panic,
+    );
 
     let meta = {
         let mut meta = proto::Meta::new();
@@ -672,10 +680,16 @@ enum ExistingStrategy {
 }
 
 fn generate_levels(
-    output_directory: &Path, 
-    tile: &Tile, deepest_level: u8, leaves: &FnvHashSet<NodeId>, all_nodes_tx: crossbeam::channel::Sender<NodeId>, 
-    parameters: &XrayParameters, existing_strategy: ExistingStrategy) {
-    let mut nodes_to_create : FnvHashSet<NodeId> = leaves.iter().filter_map(|leaf| leaf.parent_id()).collect();
+    output_directory: &Path,
+    tile: &Tile,
+    deepest_level: u8,
+    leaves: &FnvHashSet<NodeId>,
+    all_nodes_tx: crossbeam::channel::Sender<NodeId>,
+    parameters: &XrayParameters,
+    existing_strategy: ExistingStrategy,
+) {
+    let mut nodes_to_create: FnvHashSet<NodeId> =
+        leaves.iter().filter_map(|leaf| leaf.parent_id()).collect();
     for current_level in (0..deepest_level).rev() {
         //let nodes_to_create: FnvHashSet<NodeId> = parents_to_create_rx.into_iter().collect();
         let progress_bar = create_syncable_progress_bar(
@@ -687,7 +701,9 @@ fn generate_levels(
             let image_path = get_image_path(output_directory, node_id);
             if image_path.exists() {
                 match existing_strategy {
-                    ExistingStrategy::Panic => {panic!("{:?} already exists.", image_path);}
+                    ExistingStrategy::Panic => {
+                        panic!("{:?} already exists.", image_path);
+                    }
                     ExistingStrategy::Skip => {
                         if let Some(id) = node_id.parent_id() {
                             parents_to_create_tx.send(id).unwrap()
@@ -695,7 +711,10 @@ fn generate_levels(
                         all_nodes_tx.send(node_id).unwrap();
                         return ();
                     }
-                    ExistingStrategy::Replace => {std::fs::remove_file(image_path.clone()).expect(&format!("Cannot remove file: {:?}.", image_path));}
+                    ExistingStrategy::Replace => {
+                        std::fs::remove_file(image_path.clone())
+                            .expect(&format!("Cannot remove file: {:?}.", image_path));
+                    }
                 }
             }
             all_nodes_tx.send(node_id).unwrap();

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -557,7 +557,6 @@ pub fn build_xray_quadtree(
     );
 
     // Create the deepest level of the quadtree.
-    let mut all_nodes = FnvHashSet::default();
     let (created_leaf_node_ids_tx, created_leaf_node_ids_rx) = crossbeam::channel::unbounded();
 
     let mut leaf_nodes = Vec::with_capacity(4usize.pow(deepest_level.into()));
@@ -627,6 +626,7 @@ pub fn build_xray_quadtree(
     });
     progress_bar.lock().unwrap().finish_println("");
 
+    let mut all_nodes = FnvHashSet::default();
     let mut previous_level_nodes = created_leaf_node_ids;
     for node in &previous_level_nodes {
         all_nodes.insert(*node);

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -680,7 +680,6 @@ pub fn build_xray_quadtree(
 #[derive(Clone, Copy, Debug)]
 enum ExistingStrategy {
     Skip,
-    Replace,
     // TODO(kpopielarz): replace this by ErrorOut or something similar.
     Panic,
 }
@@ -724,10 +723,6 @@ fn build_node(
             }
             ExistingStrategy::Skip => {
                 return ();
-            }
-            ExistingStrategy::Replace => {
-                std::fs::remove_file(image_path.clone())
-                    .expect(&format!("Cannot remove file: {:?}.", image_path));
             }
         }
     }

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -688,24 +688,24 @@ fn build_level(
     output_directory: &Path,
     tile: &Tile,
     current_level: u8,
-    lower_level: &FnvHashSet<NodeId>,
+    previous_level_nods: &FnvHashSet<NodeId>,
     parameters: &XrayParameters,
     existing_strategy: ExistingStrategy,
 ) -> FnvHashSet<NodeId> {
-    let nodes_to_create: FnvHashSet<NodeId> = lower_level
+    let current_level_nodes: FnvHashSet<NodeId> = previous_level_nods
         .iter()
         .filter_map(|node| node.parent_id())
         .collect();
     let progress_bar = create_syncable_progress_bar(
-        nodes_to_create.len(),
+        current_level_nodes.len(),
         &format!("Building level {}", current_level),
     );
-    nodes_to_create.par_iter().for_each(|node| {
+    current_level_nodes.par_iter().for_each(|node| {
         build_node(output_directory, *node, tile, parameters, existing_strategy);
         progress_bar.lock().unwrap().inc();
     });
     progress_bar.lock().unwrap().finish_println("");
-    nodes_to_create
+    current_level_nodes
 }
 
 fn build_node(
@@ -748,10 +748,6 @@ fn build_node(
             tile.size_px,
             image::imageops::FilterType::Lanczos3,
         );
-        image
-            .as_rgba8()
-            .unwrap()
-            .save(&image_path)
-            .unwrap();
+        image.as_rgba8().unwrap().save(&image_path).unwrap();
     }
 }

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -626,11 +626,11 @@ pub fn build_xray_quadtree(
     });
     progress_bar.lock().unwrap().finish_println("");
 
-    let mut previous_level_nodes = created_leaf_node_ids;
-    let mut all_nodes = previous_level_nodes.clone();
+    let mut current_level_nodes = created_leaf_node_ids;
+    let mut all_nodes = current_level_nodes.clone();
 
     for current_level in (0..deepest_level).rev() {
-        let current_level_nodes: FnvHashSet<NodeId> = previous_level_nodes
+        current_level_nodes = current_level_nodes
             .iter()
             .filter_map(|node| node.parent_id())
             .collect();
@@ -642,7 +642,6 @@ pub fn build_xray_quadtree(
             parameters,
         );
         all_nodes.extend(&current_level_nodes);
-        previous_level_nodes = current_level_nodes;
     }
 
     let meta = {


### PR DESCRIPTION
# What changed
* Created a new function `generation::build_level` which generates a new level based on nodes from level above;
* For simplification reasons removed `parents_to_create_{tx,rx}`, `all_nodes_{tx,rx}` crossbeam channels. The performance shouldn't be affected;
* Some minor refactorings.
# Tests
Produced xrays from both master and this branch, computed md5 checksums for each of the produced files and verified that they are consistent (except for `meta.pb`), and visualized the xrays.