### PR TITLE
Add option to specify node id for X-ray quadtree generation

### DIFF
--- a/quadtree/src/lib.rs
+++ b/quadtree/src/lib.rs
@@ -55,13 +55,6 @@ pub struct Node {
 }
 
 impl Node {
-    pub fn root_with_bounding_rect(rect: Rect) -> Self {
-        Node {
-            id: NodeId::root(),
-            bounding_rect: rect,
-        }
-    }
-
     pub fn from_node_id_and_root_bounding_rect(id: NodeId, rect: Rect) -> Self {
         let mut ids = vec![id];
         while let Some(parent_id) = ids.last().and_then(|last| last.parent_id()) {

--- a/quadtree/src/lib.rs
+++ b/quadtree/src/lib.rs
@@ -62,6 +62,21 @@ impl Node {
         }
     }
 
+    pub fn from_node_id_and_root_bounding_rect(id: NodeId, rect: Rect) -> Self {
+        let mut ids = vec![id];
+        while let Some(parent_id) = ids.last().and_then(|last| last.parent_id()) {
+            ids.push(parent_id);
+        }
+        let mut node = Self {
+            id: ids.pop().unwrap(),
+            bounding_rect: rect,
+        };
+        while let Some(child_id) = ids.pop().and_then(|id| id.child_index()) {
+            node = node.get_child(&child_id);
+        }
+        node
+    }
+
     pub fn get_child(&self, child_index: &ChildIndex) -> Node {
         let child_bounding_rect = {
             let half_edge_length = self.bounding_rect.edge_length() / 2.;

--- a/quadtree/src/lib.rs
+++ b/quadtree/src/lib.rs
@@ -55,15 +55,21 @@ pub struct Node {
 }
 
 impl Node {
+    /// Returns the node corresponding to a specific node id within the quadtree
+    /// and the bounding rect covering the whole quadtree
     pub fn from_node_id_and_root_bounding_rect(id: NodeId, rect: Rect) -> Self {
         let mut ids = vec![id];
+        // Find all nodes on the way from the sub root node to the root node
         while let Some(parent_id) = ids.last().and_then(|last| last.parent_id()) {
             ids.push(parent_id);
         }
+        // Create the root node
         let mut node = Self {
             id: ids.pop().unwrap(),
             bounding_rect: rect,
         };
+        // Traverse from the root node to the sub root node to find the actual bounding
+        // rect of the sub root node
         while let Some(child_index) = ids.pop().and_then(|id| id.child_index()) {
             node = node.get_child(&child_index);
         }

--- a/quadtree/src/lib.rs
+++ b/quadtree/src/lib.rs
@@ -64,8 +64,8 @@ impl Node {
             id: ids.pop().unwrap(),
             bounding_rect: rect,
         };
-        while let Some(child_id) = ids.pop().and_then(|id| id.child_index()) {
-            node = node.get_child(&child_id);
+        while let Some(child_index) = ids.pop().and_then(|id| id.child_index()) {
+            node = node.get_child(&child_index);
         }
         node
     }

--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -9,6 +9,7 @@ use point_viewer::data_provider::DataProviderFactory;
 use point_viewer::math::{ClosedInterval, Isometry3};
 use point_viewer::read_write::attempt_increasing_rlimit_to_max;
 use point_viewer::utils::parse_key_val;
+use quadtree::NodeId;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -110,6 +111,11 @@ fn parse_arguments<T: Extension>() -> clap::ArgMatches<'static> {
                 .long("inpaint-distance-px")
                 .takes_value(true)
                 .default_value("0"),
+            clap::Arg::with_name("root_node_id")
+                .help("The root node id to start building with.")
+                .long("root-node-id")
+                .takes_value(true)
+                .default_value("r"),
         ]);
     app = T::pre_init(app);
     app.get_matches()
@@ -196,12 +202,18 @@ pub fn run<T: Extension>(data_provider_factory: DataProviderFactory) {
         .unwrap()
         .parse::<u8>()
         .expect("inpaint_distance_px could not be parsed.");
+    let root_node_id = args
+        .value_of("root_node_id")
+        .unwrap()
+        .parse::<NodeId>()
+        .expect("root_node_id could not be parsed.");
     let parameters = XrayParameters {
         point_cloud_client,
         query_from_global: T::query_from_global(&args),
         filter_intervals,
         tile_background_color,
         inpaint_distance_px,
+        root_node_id,
     };
     build_xray_quadtree(
         output_directory,

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -562,6 +562,10 @@ pub fn build_xray_quadtree(
 
     let root_node_id = parameters.root_node_id;
     let root_level = root_node_id.level();
+    assert!(
+        root_level <= deepest_level,
+        "Specified root node id is outside quadtree."
+    );
     let root_node = Node::from_node_id_and_root_bounding_rect(root_node_id, bounding_rect.clone());
     let mut leaf_nodes = Vec::with_capacity(4usize.pow((deepest_level - root_level).into()));
     let mut nodes_to_traverse = Vec::with_capacity((4 * leaf_nodes.capacity() - 1) / 3);

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -463,6 +463,7 @@ pub struct XrayParameters {
     pub filter_intervals: HashMap<String, ClosedInterval<f64>>,
     pub tile_background_color: Color<u8>,
     pub inpaint_distance_px: u8,
+    pub root_node_id: NodeId,
 }
 
 pub fn xray_from_points(
@@ -561,7 +562,10 @@ pub fn build_xray_quadtree(
 
     let mut leaf_nodes = Vec::with_capacity(4usize.pow(deepest_level.into()));
     let mut nodes_to_traverse = Vec::with_capacity((4 * leaf_nodes.capacity() - 1) / 3);
-    nodes_to_traverse.push(Node::root_with_bounding_rect(bounding_rect.clone()));
+    nodes_to_traverse.push(Node::from_node_id_and_root_bounding_rect(
+        parameters.root_node_id,
+        bounding_rect.clone(),
+    ));
     while let Some(node) = nodes_to_traverse.pop() {
         if node.level() == deepest_level {
             leaf_nodes.push(node);

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -671,7 +671,7 @@ pub fn build_xray_quadtree(
         meta
     };
 
-    let meta_pb_name = format!("{}.pb", root_node_id.to_string().replace("r", "meta"));
+    let meta_pb_name = format!("{}.pb", root_node_id).replace("r", "meta");
     let mut buf_writer = BufWriter::new(File::create(output_directory.join(meta_pb_name)).unwrap());
     meta.write_to_writer(&mut buf_writer).unwrap();
 

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -560,12 +560,12 @@ pub fn build_xray_quadtree(
     // Create the deepest level of the quadtree.
     let (created_leaf_node_ids_tx, created_leaf_node_ids_rx) = crossbeam::channel::unbounded();
 
-    let mut leaf_nodes = Vec::with_capacity(4usize.pow(deepest_level.into()));
+    let root_node_id = parameters.root_node_id;
+    let root_level = root_node_id.level();
+    let root_node = Node::from_node_id_and_root_bounding_rect(root_node_id, bounding_rect.clone());
+    let mut leaf_nodes = Vec::with_capacity(4usize.pow((deepest_level - root_level).into()));
     let mut nodes_to_traverse = Vec::with_capacity((4 * leaf_nodes.capacity() - 1) / 3);
-    nodes_to_traverse.push(Node::from_node_id_and_root_bounding_rect(
-        parameters.root_node_id,
-        bounding_rect.clone(),
-    ));
+    nodes_to_traverse.push(root_node);
     while let Some(node) = nodes_to_traverse.pop() {
         if node.level() == deepest_level {
             leaf_nodes.push(node);
@@ -633,7 +633,7 @@ pub fn build_xray_quadtree(
     let mut current_level_nodes = created_leaf_node_ids;
     let mut all_nodes = current_level_nodes.clone();
 
-    for current_level in (0..deepest_level).rev() {
+    for current_level in (root_level..deepest_level).rev() {
         current_level_nodes = current_level_nodes
             .iter()
             .filter_map(|node| node.parent_id())
@@ -671,7 +671,8 @@ pub fn build_xray_quadtree(
         meta
     };
 
-    let mut buf_writer = BufWriter::new(File::create(output_directory.join("meta.pb")).unwrap());
+    let meta_pb_name = format!("{}.pb", root_node_id.to_string().replace("r", "meta"));
+    let mut buf_writer = BufWriter::new(File::create(output_directory.join(meta_pb_name)).unwrap());
     meta.write_to_writer(&mut buf_writer).unwrap();
 
     progress_bar.lock().unwrap().finish();

--- a/xray/src/lib.rs
+++ b/xray/src/lib.rs
@@ -115,8 +115,7 @@ impl Meta {
             NodeId::root(),
             self.bounding_rect.clone(),
         )];
-        while !open.is_empty() {
-            let node = open.pop().unwrap();
+        while let Some(node) = open.pop() {
             let aabb = Aabb3::new(
                 Point3::new(node.bounding_rect.min().x, node.bounding_rect.min().y, -0.1),
                 Point3::new(node.bounding_rect.max().x, node.bounding_rect.max().y, 0.1),

--- a/xray/src/lib.rs
+++ b/xray/src/lib.rs
@@ -111,7 +111,10 @@ impl Meta {
         let frustum =
             Frustum::from_matrix4(matrix).ok_or("Unable to create frustum from matrix")?;
         let mut result = Vec::new();
-        let mut open = vec![Node::root_with_bounding_rect(self.bounding_rect.clone())];
+        let mut open = vec![Node::from_node_id_and_root_bounding_rect(
+            NodeId::root(),
+            self.bounding_rect.clone(),
+        )];
         while !open.is_empty() {
             let node = open.pop().unwrap();
             let aabb = Aabb3::new(


### PR DESCRIPTION
This enables the generation of sub-quadtrees, which later can be merged. This is a useful feature for sharding quadtree generation.