### PR TITLE
xray merger interface

### DIFF
--- a/xray/src/bin/merge_xray_quadtrees.rs
+++ b/xray/src/bin/merge_xray_quadtrees.rs
@@ -7,12 +7,17 @@ use structopt::StructOpt;
 /// of each quadtree belongs to the same level of the final
 /// quadtree.
 struct CommandlineArguments {
-    /// Directory with partial xray quadtrees.
+    /// Directory where to write the merged quadtree. Does *not*
+    /// have to be disjoint from input_directories.
+    #[structopt(parse(from_os_str), long = "output_directory")]
+    output_directory: PathBuf,
+    /// Directories with, possibly multiple, partial xray quadtrees.
     #[structopt(parse(from_os_str))]
-    directory: PathBuf,
+    input_directories: Vec<PathBuf>,
 }
 
 fn main() {
-    let _args = CommandlineArguments::from_args();
+    let args = CommandlineArguments::from_args();
+    dbg!(args);
     unimplemented!();
 }

--- a/xray/src/bin/merge_xray_quadtrees.rs
+++ b/xray/src/bin/merge_xray_quadtrees.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use structopt::StructOpt;
+use xray::generation;
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "merge_xray_quadtrees")]
@@ -11,6 +12,9 @@ struct CommandlineArguments {
     /// have to be disjoint from input_directories.
     #[structopt(parse(from_os_str), long = "output_directory")]
     output_directory: PathBuf,
+    #[structopt(parse(from_os_str), default_value = "white")]
+    /// ...
+    tile_background_color: generation::TileBackgroundColorArgument,
     /// Directories with, possibly multiple, partial xray quadtrees.
     #[structopt(parse(from_os_str))]
     input_directories: Vec<PathBuf>,

--- a/xray/src/bin/merge_xray_quadtrees.rs
+++ b/xray/src/bin/merge_xray_quadtrees.rs
@@ -1,0 +1,18 @@
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "merge_xray_quadtrees")]
+/// Merge partial xray octrees. We assume that the root
+/// of each quadtree belongs to the same level of the final
+/// quadtree.
+struct CommandlineArguments {
+    /// Directory with partial xray quadtrees.
+    #[structopt(parse(from_os_str))]
+    directory: PathBuf,
+}
+
+fn main() {
+    let _args = CommandlineArguments::from_args();
+    unimplemented!();
+}

--- a/xray/src/bin/merge_xray_quadtrees.rs
+++ b/xray/src/bin/merge_xray_quadtrees.rs
@@ -3,7 +3,7 @@ use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "merge_xray_quadtrees")]
-/// Merge partial xray octrees. We assume that the root
+/// Merge partial xray quadtrees. We assume that the root
 /// of each quadtree belongs to the same level of the final
 /// quadtree.
 struct CommandlineArguments {

--- a/xray/src/bin/merge_xray_quadtrees.rs
+++ b/xray/src/bin/merge_xray_quadtrees.rs
@@ -15,9 +15,6 @@ struct CommandlineArguments {
     /// Tile background color.
     #[structopt(default_value = "white", long)]
     tile_background_color: generation::TileBackgroundColorArgument,
-    /// Tile size.
-    #[structopt(default_value = "256", long)]
-    tile_size: u32,
     /// Directories with, possibly multiple, partial xray quadtrees.
     #[structopt(parse(from_os_str))]
     input_directories: Vec<PathBuf>,

--- a/xray/src/bin/merge_xray_quadtrees.rs
+++ b/xray/src/bin/merge_xray_quadtrees.rs
@@ -10,11 +10,14 @@ use xray::generation;
 struct CommandlineArguments {
     /// Directory where to write the merged quadtree. Does *not*
     /// have to be disjoint from input_directories.
-    #[structopt(parse(from_os_str), long = "output_directory")]
+    #[structopt(parse(from_os_str), long)]
     output_directory: PathBuf,
-    #[structopt(parse(from_os_str), default_value = "white")]
-    /// ...
+    /// Tile background color.
+    #[structopt(default_value = "white", long)]
     tile_background_color: generation::TileBackgroundColorArgument,
+    /// Tile size.
+    #[structopt(default_value = "256", long)]
+    tile_size: u32,
     /// Directories with, possibly multiple, partial xray quadtrees.
     #[structopt(parse(from_os_str))]
     input_directories: Vec<PathBuf>,


### PR DESCRIPTION
```
$ cargo run --bin merge_xray_quadtrees -- --output_directory /mnt/disk . ../ a/ a/b/c/
[xray/src/bin/merge_xray_quadtrees.rs:21] args = CommandlineArguments {
    output_directory: "/mnt/disk",
    input_directories: [
        ".",
        "../",
        "a/",
        "a/b/c/",
    ],
}
thread 'main' panicked at 'not implemented', xray/src/bin/merge_xray_quadtrees.rs:22:5
```

```
$ cargo run --bin merge_xray_quadtrees -- --help
merge_xray_quadtrees 0.1.0
Merge partial xray quadtrees. We assume that the root of each quadtree belongs to the same level of the final quadtree

USAGE:
    merge_xray_quadtrees --output_directory <output-directory> [input-directories]...

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --output_directory <output-directory>
            Directory where to write the merged quadtree. Does *not* have to be disjoint from input_directories


ARGS:
    <input-directories>...    Directories with, possibly multiple, partial xray quadtrees
```