### PR TITLE
Redirect progress and logs to stderr.

### DIFF
--- a/octree_web_viewer/src/backend.rs
+++ b/octree_web_viewer/src/backend.rs
@@ -162,7 +162,7 @@ pub async fn get_nodes_data(
     }
 
     let duration_ms = start.elapsed().as_seconds_f64() * 1_000.;
-    println!(
+    eprintln!(
         "Got {} nodes with {} points ({}ms).",
         num_nodes_fetched, num_points, duration_ms
     );

--- a/octree_web_viewer/src/bin/points_web_viewer.rs
+++ b/octree_web_viewer/src/bin/points_web_viewer.rs
@@ -68,6 +68,6 @@ fn main() {
     let sys = actix::System::new("octree-server");
     let _ = start_octree_server(app_state, &ip_port);
 
-    println!("Starting http server: {}", &ip_port);
+    eprintln!("Starting http server: {}", &ip_port);
     let _ = sys.run();
 }

--- a/point_cloud_client/src/bin/test.rs
+++ b/point_cloud_client/src/bin/test.rs
@@ -80,7 +80,7 @@ fn main() {
         point_count += points_batch.position.len();
         if point_count >= print_count * BATCH_SIZE {
             print_count += 1;
-            println!("Streamed {}M points", point_count / BATCH_SIZE);
+            eprintln!("Streamed {}M points", point_count / BATCH_SIZE);
         }
         if point_count >= num_points {
             return Err(std::io::Error::new(
@@ -96,7 +96,7 @@ fn main() {
         Err(e) => match e.kind() {
             ErrorKind::Io(ref e) if e.kind() == std::io::ErrorKind::Interrupted => (),
             _ => {
-                println!("Encountered error:\n{}", e);
+                eprintln!("Encountered error:\n{}", e);
                 std::process::exit(1);
             }
         },

--- a/point_viewer_grpc/src/bin/octree_benchmark.rs
+++ b/point_viewer_grpc/src/bin/octree_benchmark.rs
@@ -111,13 +111,13 @@ fn server_benchmark(
         num_threads,
         buffer_size,
     );
-    println!("Server benchmark:");
+    eprintln!("Server benchmark:");
     let _result = parallel_iterator.try_for_each_batch(move |points_batch| {
         counter += points_batch.position.len();
 
         if points_streamed_m < counter / 1_000_000 {
             points_streamed_m = counter / 1_000_000;
-            println!("Streamed {}M points", points_streamed_m)
+            eprintln!("Streamed {}M points", points_streamed_m)
         };
         if counter >= num_points {
             std::process::exit(0)
@@ -144,7 +144,7 @@ fn full_benchmark(octree_directory: &Path, num_points: usize, port: u16) {
     'outer: for rep in receiver.wait() {
         for _pos in rep.expect("Stream error").get_positions().iter() {
             if counter % 1_000_000 == 0 {
-                println!("Streamed {}M points", counter / 1_000_000);
+                eprintln!("Streamed {}M points", counter / 1_000_000);
             }
             counter += 1;
             if counter == num_points {

--- a/point_viewer_grpc/src/bin/octree_server.rs
+++ b/point_viewer_grpc/src/bin/octree_server.rs
@@ -49,10 +49,10 @@ fn main() {
     server.start();
 
     for &(ref host, port) in server.bind_addrs() {
-        println!("listening on {}:{}", host, port);
+        eprintln!("listening on {}:{}", host, port);
     }
     let rx: crossbeam_channel::Receiver<()> = ctrlc_channel().unwrap();
-    println!("Exit with Ctrl-C");
+    eprintln!("Exit with Ctrl-C");
     let _ = rx.recv();
     let _ = server.shutdown().wait();
 }

--- a/point_viewer_grpc/src/service.rs
+++ b/point_viewer_grpc/src/service.rs
@@ -78,7 +78,7 @@ impl proto_grpc::Octree for OctreeService {
         resp.set_meta(service_data.meta.clone());
         let f = sink
             .success(resp)
-            .map_err(move |e| println!("failed to reply {:?}: {:?}", req, e));
+            .map_err(move |e| eprintln!("failed to reply {:?}: {:?}", req, e));
         ctx.spawn(f)
     }
 
@@ -108,7 +108,7 @@ impl proto_grpc::Octree for OctreeService {
         resp.set_color(node_data.color);
         let f = sink
             .success(resp)
-            .map_err(move |e| println!("failed to reply {:?}: {:?}", req, e));
+            .map_err(move |e| eprintln!("failed to reply {:?}: {:?}", req, e));
         ctx.spawn(f)
     }
 
@@ -317,7 +317,7 @@ impl OctreeService {
         let f = resp
             .send_all(rx)
             .map(|_| {})
-            .map_err(|e| println!("failed to reply: {:?}", e));
+            .map_err(|e| eprintln!("failed to reply: {:?}", e));
         ctx.spawn(f)
     }
 

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -229,7 +229,7 @@ impl PointCloudRenderer {
             }
             self.num_frames = 0;
             self.last_log = now;
-            println!(
+            eprintln!(
                 "FPS: {:.2}, Drew {} points from {} loaded nodes. {} nodes \
                  should be shown, Cache {} MB",
                 fps,
@@ -250,7 +250,7 @@ pub struct CameraStates {
 
 fn save_camera(index: usize, pose_path: &Option<PathBuf>, camera: &Camera) {
     if pose_path.is_none() {
-        println!("Not serving from a local directory. Cannot save camera.");
+        eprintln!("Not serving from a local directory. Cannot save camera.");
         return;
     }
     assert!(index < 10);
@@ -269,18 +269,18 @@ fn save_camera(index: usize, pose_path: &Option<PathBuf>, camera: &Camera) {
         serde_json::to_string_pretty(&states).unwrap().as_bytes(),
     ) {
         Ok(_) => (),
-        Err(e) => println!(
+        Err(e) => eprintln!(
             "Could not write {}: {}",
             pose_path.as_ref().unwrap().display(),
             e
         ),
     }
-    println!("Saved current camera position as {}.", index);
+    eprintln!("Saved current camera position as {}.", index);
 }
 
 fn load_camera(index: usize, pose_path: &Option<PathBuf>, camera: &mut Camera) {
     if pose_path.is_none() {
-        println!("Not serving from a local directory. Cannot load camera.");
+        eprintln!("Not serving from a local directory. Cannot load camera.");
         return;
     }
     assert!(index < 10);
@@ -424,7 +424,7 @@ pub fn run<T: Extension>(data_provider_factory: DataProviderFactory) {
                 )
             };
 
-            println!(
+            eprintln!(
                 "Found a joystick named '{}' ({} axes, {} buttons, {} balls, {} hats). Will treat it as a {}.",
                 j.joystick().name(),
                 j.joystick().num_axes(),

--- a/src/bin/upgrade_octree.rs
+++ b/src/bin/upgrade_octree.rs
@@ -36,7 +36,7 @@ fn write_meta(directory: &Path, mut meta: proto::Meta, version: i32) {
 }
 
 fn upgrade_version9(directory: &Path, mut meta: proto::Meta) {
-    println!("Upgrading version 9 => 10.");
+    eprintln!("Upgrading version 9 => 10.");
     for node_proto in &mut meta.deprecated_nodes.iter_mut() {
         let mut id = node_proto.id.as_mut().unwrap();
         let node_id = NodeId::from_proto(id);
@@ -48,7 +48,7 @@ fn upgrade_version9(directory: &Path, mut meta: proto::Meta) {
 }
 
 fn upgrade_version10(directory: &Path, mut meta: proto::Meta) {
-    println!("Upgrading version 10 => 11.");
+    eprintln!("Upgrading version 10 => 11.");
     let bbox = meta.bounding_box.as_mut().unwrap();
     let deprecated_min = bbox.take_deprecated_min();
     bbox.set_min(point_viewer::proto::Vector3d::from(deprecated_min));
@@ -58,7 +58,7 @@ fn upgrade_version10(directory: &Path, mut meta: proto::Meta) {
 }
 
 fn upgrade_version11(directory: &Path, mut meta: proto::Meta) {
-    println!("Upgrading version 11 => 12.");
+    eprintln!("Upgrading version 11 => 12.");
     let mut octree = proto::OctreeMeta::new();
 
     octree.set_resolution(meta.deprecated_resolution);
@@ -71,7 +71,7 @@ fn upgrade_version11(directory: &Path, mut meta: proto::Meta) {
 }
 
 fn upgrade_version12(directory: &Path, mut meta: proto::Meta) {
-    println!("Upgrading version 12 => 13.");
+    eprintln!("Upgrading version 12 => 13.");
     if meta.has_octree() {
         let bounding_box = meta.mut_octree().take_deprecated_bounding_box();
         meta.set_bounding_box(bounding_box);
@@ -95,14 +95,14 @@ fn main() {
             11 => upgrade_version11(&args.directory, meta),
             12 => upgrade_version12(&args.directory, meta),
             other if other == point_viewer::CURRENT_VERSION => {
-                println!(
+                eprintln!(
                     "Point cloud at current version {}",
                     point_viewer::CURRENT_VERSION
                 );
                 break;
             }
             other => {
-                println!("Do not know how to upgrade version {}", other);
+                eprintln!("Do not know how to upgrade version {}", other);
                 std::process::exit(1);
             }
         }

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -153,7 +153,7 @@ impl Octree {
     pub fn from_data_provider(data_provider: Box<dyn DataProvider>) -> Result<Self> {
         let meta_proto = data_provider.meta_proto()?;
         if meta_proto.version < CURRENT_VERSION {
-            println!(
+            eprintln!(
                 "Data is an older octree version: {}, current would be {}. \
                  If feasible, try upgrading this octree using `upgrade_octree`.",
                 meta_proto.version, CURRENT_VERSION

--- a/src/octree/tests.rs
+++ b/src/octree/tests.rs
@@ -64,12 +64,12 @@ impl Consumer {
     fn consume(&mut self, points_batch: PointsBatch) -> Result<()> {
         self.num_received_callbacks += 1;
         self.num_received_points += points_batch.position.len();
-        println!(
+        eprintln!(
             "Callback_count {}, delivered points {}",
             self.num_received_callbacks, self.num_received_points
         );
         if self.num_received_points >= self.max_num_points {
-            println!("Callback: Max Points reached!");
+            eprintln!("Callback: Max Points reached!");
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Interrupted,
                 format!("Maximum number of {} points reached.", self.max_num_points),

--- a/src/read_write/ply.rs
+++ b/src/read_write/ply.rs
@@ -295,7 +295,7 @@ macro_rules! push_reader {
 // pointer.
 macro_rules! push_skip_reader {
     ($prop:expr, &mut $size:ident, $num_bytes:expr) => {{
-        println!("Will ignore property '{}' on 'vertex'.", $prop.name);
+        eprintln!("Will ignore property '{}' on 'vertex'.", $prop.name);
         $size += $num_bytes;
         fn _read_fn(nread: &mut usize, _: &[u8], _: &mut AttributeData) {
             *nread += $num_bytes;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use pbr::ProgressBar;
 use std::error::Error;
-use std::io::Stdout;
+use std::io;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -20,8 +20,8 @@ where
     Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }
 
-pub fn create_progress_bar(total: usize, message: &str) -> ProgressBar<Stdout> {
-    let mut progress_bar = ProgressBar::new(total as u64);
+pub fn create_progress_bar(total: usize, message: &str) -> ProgressBar<io::Stderr> {
+    let mut progress_bar = ProgressBar::on(io::stderr(), total as u64);
     progress_bar.set_max_refresh_rate(Some(PROGRESS_REFRESH_RATE));
     progress_bar.message(&format!("{}: ", message));
     progress_bar
@@ -30,6 +30,6 @@ pub fn create_progress_bar(total: usize, message: &str) -> ProgressBar<Stdout> {
 pub fn create_syncable_progress_bar(
     total: usize,
     message: &str,
-) -> Arc<Mutex<ProgressBar<Stdout>>> {
+) -> Arc<Mutex<ProgressBar<io::Stderr>>> {
     Arc::new(Mutex::new(create_progress_bar(total, message)))
 }

--- a/xray/src/bin/inpaint_xray_quadtree.rs
+++ b/xray/src/bin/inpaint_xray_quadtree.rs
@@ -111,7 +111,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         get_adjacent_leaf_node_ids(&leaf_node_ids, &input_directory, root_node_id);
     if root_node_id.level() != 0 && adjacent_leaf_node_ids.is_empty() {
         // TODO(feuerste): Replace with slog warn.
-        println!(
+        eprintln!(
             "No adjacent leaf nodes found in neighboring quadtrees. \
              Did you forget to copy them into {:?}?",
             &input_directory

--- a/xray/src/bin/merge_xray_quadtrees.rs
+++ b/xray/src/bin/merge_xray_quadtrees.rs
@@ -79,7 +79,7 @@ fn read_metadata_from_directories(directories: &[PathBuf]) -> Vec<Meta> {
 fn get_root_nodes(meta: &[Meta]) -> Vec<Node> {
     let root_nodes: Vec<Node> = meta.iter().filter_map(Meta::get_root_node).collect();
     if root_nodes.len() != meta.len() {
-        println!(
+        eprintln!(
             "Skipped {} empty subquadtrees.",
             meta.len() - root_nodes.len()
         );

--- a/xray/src/bin/upgrade_xray_quadtree.rs
+++ b/xray/src/bin/upgrade_xray_quadtree.rs
@@ -28,7 +28,7 @@ struct CommandlineArguments {
 }
 
 fn upgrade_version2(filename: &Path, mut meta: proto::Meta) {
-    println!("Upgrading version 2 => 3.");
+    eprintln!("Upgrading version 2 => 3.");
     let bounding_rect = meta.mut_bounding_rect();
     let deprecated_min = bounding_rect.get_deprecated_min();
     let mut min = proto::Vector2d::new();
@@ -56,11 +56,11 @@ fn main() {
         match meta.version {
             2 => upgrade_version2(&filename, meta),
             other if other == xray::CURRENT_VERSION => {
-                println!("Xray quadtree at current version {}", xray::CURRENT_VERSION);
+                eprintln!("Xray quadtree at current version {}", xray::CURRENT_VERSION);
                 break;
             }
             other => {
-                println!("Do not know how to upgrade version {}", other);
+                eprintln!("Do not know how to upgrade version {}", other);
                 std::process::exit(1);
             }
         }

--- a/xray/src/bin/web_viewer.rs
+++ b/xray/src/bin/web_viewer.rs
@@ -74,6 +74,6 @@ fn main() {
     )
     .unwrap();
 
-    println!("Listening on port {}.", port);
+    eprintln!("Listening on port {}.", port);
     Iron::new(router).http(("0.0.0.0", port)).unwrap();
 }

--- a/xray/src/lib.rs
+++ b/xray/src/lib.rs
@@ -62,7 +62,7 @@ impl Meta {
     // Reads the meta from the provided encoded protobuf.
     pub fn from_proto(proto: &proto::Meta) -> Self {
         match proto.version {
-            2 => println!(
+            2 => eprintln!(
                 "Data is an older xray quadtree version: {}, current would be {}. \
                  If feasible, try upgrading this xray quadtree using `upgrade_xray_quadtree`.",
                 proto.version, CURRENT_VERSION


### PR DESCRIPTION
This is a first step towards proper logging. On `stdout` we only want program outputs.